### PR TITLE
Fixed immutability issues

### DIFF
--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/CompileTestBuilder.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/CompileTestBuilder.java
@@ -24,6 +24,9 @@ public class CompileTestBuilder {
      */
     public static abstract class BasicBuilder<T extends BasicBuilder<T>> {
 
+        /**
+         * the current immutable CompileTestConfiguration
+         */
         protected final CompileTestConfiguration compileTestConfiguration;
 
         protected BasicBuilder(CompileTestConfiguration compileTestConfiguration) {
@@ -59,7 +62,7 @@ public class CompileTestBuilder {
          * @param warningChecks the warning checks to set, null values will be ignored.
          * @return the next builder instance
          */
-        public T addWarningChecks(String... warningChecks) {
+        public T expectedWarningMessages(String... warningChecks) {
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (warningChecks != null) {
                 nextConfiguration.addWarningMessageCheck(warningChecks);
@@ -74,7 +77,7 @@ public class CompileTestBuilder {
          * @param mandatoryWarningChecks the mandatory warning checks to set, null values will be ignored.
          * @return the next builder instance
          */
-        public T addMandatoryWarningChecks(String... mandatoryWarningChecks) {
+        public T expectedMandatoryWarningMessages(String... mandatoryWarningChecks) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (mandatoryWarningChecks != null) {
@@ -90,7 +93,7 @@ public class CompileTestBuilder {
          * @param errorChecksToSet the error checks to set, null values will be ignored.
          * @return the next builder instance
          */
-        public T addErrorChecks(String... errorChecksToSet) {
+        public T expectedErrorMessages(String... errorChecksToSet) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (errorChecksToSet != null) {
@@ -106,7 +109,7 @@ public class CompileTestBuilder {
          * @param noteChecksToSet the notes checks to set, null values will be ignored.
          * @return the next builder instance
          */
-        public T addNoteChecks(String... noteChecksToSet) {
+        public T expectedNoteMessages(String... noteChecksToSet) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (noteChecksToSet != null) {
@@ -125,8 +128,8 @@ public class CompileTestBuilder {
          * @param relativeName
          * @return the next builder instance
          */
-        public T addGeneratedFileObjectExistsCheck(JavaFileManager.Location location, String packageName, String relativeName) {
-            return addGeneratedFileObjectExistsCheck(location, packageName, relativeName, (FileObject) null);
+        public T expectedFileObjectExists(JavaFileManager.Location location, String packageName, String relativeName) {
+            return expectedFileObjectExists(location, packageName, relativeName, (FileObject) null);
         }
 
         /**
@@ -139,10 +142,14 @@ public class CompileTestBuilder {
          * @param expectedFileObject
          * @return the next builder instance
          */
-        public T addGeneratedFileObjectExistsCheck(JavaFileManager.Location location, String packageName, String relativeName, FileObject expectedFileObject) {
+        public T expectedFileObjectExists(
+                JavaFileManager.Location location,
+                String packageName,
+                String relativeName,
+                FileObject expectedFileObject) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
-            nextConfiguration.addExpectedGeneratedFileObjectCheck(location, packageName, relativeName, expectedFileObject);
+            nextConfiguration.addGeneratedFileObjectCheck(location, packageName, relativeName, expectedFileObject);
             return createNextInstance(nextConfiguration);
 
         }
@@ -157,10 +164,14 @@ public class CompileTestBuilder {
          * @param generatedFileObjectMatcher
          * @return the next builder instance
          */
-        public T addGeneratedFileObjectExistsCheck(JavaFileManager.Location location, String packageName, String relativeName, GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher) {
+        public T expectedFileObjectExists(
+                JavaFileManager.Location location,
+                String packageName,
+                String relativeName,
+                GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
-            nextConfiguration.addExpectedGeneratedFileObjectCheck(location, packageName, relativeName, generatedFileObjectMatcher);
+            nextConfiguration.addGeneratedFileObjectCheck(location, packageName, relativeName, generatedFileObjectMatcher);
             return createNextInstance(nextConfiguration);
 
         }
@@ -173,8 +184,8 @@ public class CompileTestBuilder {
          * @param kind
          * @return the next builder instance
          */
-        public T addGeneratedJavaFileObjectExistsCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind) {
-            return addGeneratedJavaFileObjectExistsCheck(location, className, kind, (JavaFileObject) null);
+        public T expectedJavaFileObjectExists(JavaFileManager.Location location, String className, JavaFileObject.Kind kind) {
+            return expectedJavaFileObjectExists(location, className, kind, (JavaFileObject) null);
         }
 
         /**
@@ -187,10 +198,14 @@ public class CompileTestBuilder {
          * @param expectedJavaFileObject
          * @return the next builder instance
          */
-        public T addGeneratedJavaFileObjectExistsCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, JavaFileObject expectedJavaFileObject) {
+        public T expectedJavaFileObjectExists(
+                JavaFileManager.Location location,
+                String className,
+                JavaFileObject.Kind kind,
+                JavaFileObject expectedJavaFileObject) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
-            nextConfiguration.addExpectedGeneratedJavaFileObjectCheck(location, className, kind, expectedJavaFileObject);
+            nextConfiguration.addGeneratedJavaFileObjectCheck(location, className, kind, expectedJavaFileObject);
             return createNextInstance(nextConfiguration);
 
         }
@@ -205,14 +220,17 @@ public class CompileTestBuilder {
          * @param generatedJavaFileObjectCheck
          * @return the next builder instance
          */
-        public T addGeneratedJavaFileObjectExistsCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, GeneratedFileObjectMatcher<JavaFileObject> generatedJavaFileObjectCheck) {
+        public T expectedJavaFileObjectExists(
+                JavaFileManager.Location location,
+                String className,
+                JavaFileObject.Kind kind,
+                GeneratedFileObjectMatcher<JavaFileObject> generatedJavaFileObjectCheck) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
-            nextConfiguration.addExpectedGeneratedJavaFileObjectCheck(location, className, kind, generatedJavaFileObjectCheck);
+            nextConfiguration.addGeneratedJavaFileObjectCheck(location, className, kind, generatedJavaFileObjectCheck);
             return createNextInstance(nextConfiguration);
 
         }
-
 
         /**
          * Created the compile test configuration instance.
@@ -252,7 +270,7 @@ public class CompileTestBuilder {
      * Builder class used to create compile tests (== Integration tests).
      * Class is designed to produce immutable builder instances in it's fluent api.
      */
-    public static class CompileTimeTestBuilder extends BasicBuilder<CompileTimeTestBuilder> {
+    public static class CompilationTestBuilder extends BasicBuilder<CompilationTestBuilder> {
 
         /**
          * Forwarding constructor.
@@ -260,7 +278,7 @@ public class CompileTestBuilder {
          *
          * @param compileTestConfiguration
          */
-        private CompileTimeTestBuilder(CompileTestConfiguration compileTestConfiguration) {
+        private CompilationTestBuilder(CompileTestConfiguration compileTestConfiguration) {
             super(compileTestConfiguration);
         }
 
@@ -268,9 +286,9 @@ public class CompileTestBuilder {
          * Adds processors.
          *
          * @param processorTypes
-         * @return
+         * @@return the CompilationTestBuilder instance
          */
-        public CompileTimeTestBuilder useProcessors(Class<? extends Processor>... processorTypes) {
+        public CompilationTestBuilder addProcessors(Class<? extends Processor>... processorTypes) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (processorTypes != null) {
@@ -288,9 +306,9 @@ public class CompileTestBuilder {
          *
          * @param processor
          * @param exception
-         * @return
+         * @return the CompilationTestBuilder instance
          */
-        public CompileTimeTestBuilder useProcessorAndExpectException(Class<? extends Processor> processor, Class<? extends Throwable> exception) {
+        public CompilationTestBuilder addProcessorWithExpectedException(Class<? extends Processor> processor, Class<? extends Throwable> exception) {
 
             if (processor == null) {
                 throw new IllegalArgumentException("Passed processor must not be null");
@@ -304,7 +322,13 @@ public class CompileTestBuilder {
 
         }
 
-        public CompileTimeTestBuilder addSources(JavaFileObject... sources) {
+        /**
+         * Adds source files to compile to compilation test
+         *
+         * @param sources the sources to use
+         * @return the CompilationTestBuilder instance
+         */
+        public CompilationTestBuilder addSources(JavaFileObject... sources) {
 
             CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (sources != null) {
@@ -314,8 +338,11 @@ public class CompileTestBuilder {
 
         }
 
-        protected CompileTimeTestBuilder createNextInstance(CompileTestConfiguration compileTestConfiguration) {
-            return new CompileTimeTestBuilder(compileTestConfiguration);
+        /**
+         * {@inheritDoc}
+         */
+        protected CompilationTestBuilder createNextInstance(CompileTestConfiguration compileTestConfiguration) {
+            return new CompilationTestBuilder(compileTestConfiguration);
         }
 
     }
@@ -410,6 +437,9 @@ public class CompileTestBuilder {
         }
 
 
+        /**
+         * {@inheritDoc}
+         */
         public void testCompilation() {
 
             if (compileTestConfiguration.getProcessors().size() == 0) {
@@ -439,13 +469,19 @@ public class CompileTestBuilder {
             return JavaFileObjectUtils.readFromResource("/AnnotationProcessorUnitTestClass.java");
         }
 
+        /**
+         * {@inheritDoc}
+         */
         protected UnitTestBuilder createNextInstance(CompileTestConfiguration compileTestConfiguration) {
             return new UnitTestBuilder(compileTestConfiguration);
         }
 
     }
 
-    public static class TestTypeBuilder {
+    /**
+     * Internal builder class for unit and compilation tests.
+     */
+    private static class TestTypeBuilder {
 
         /**
          * Does a compilation test.
@@ -453,8 +489,8 @@ public class CompileTestBuilder {
          *
          * @return the builder
          */
-        public CompileTimeTestBuilder compilationTest() {
-            return new CompileTimeTestBuilder(new CompileTestConfiguration());
+        public CompilationTestBuilder compilationTest() {
+            return new CompilationTestBuilder(new CompileTestConfiguration());
         }
 
 
@@ -471,9 +507,28 @@ public class CompileTestBuilder {
 
     }
 
+    /**
+     * Creates a unit test builder instance.
+     * <p>
+     * Unit tests can be used to test methods that internally rely on the java compile time model
+     * or using the tools provided by the processors processing environment.
+     *
+     * @return the UnitTestBuilderm instance
+     */
+    public static UnitTestBuilder unitTest() {
+        return new TestTypeBuilder().unitTest();
+    }
 
-    public static TestTypeBuilder createCompileTestBuilder() {
-        return new TestTypeBuilder();
+    /**
+     * Creates a compilation test builder instance.
+     * <p>
+     * Compilation tests can be used for all kind of integration tests.
+     * F.e. to test behavior and outcome of a processor.
+     *
+     * @return the CompilationTestBuilder instance
+     */
+    public static CompilationTestBuilder compilationTest() {
+        return new TestTypeBuilder().compilationTest();
     }
 
 }

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/CompileTestBuilder.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/CompileTestBuilder.java
@@ -16,8 +16,6 @@ import javax.tools.JavaFileObject;
 public class CompileTestBuilder {
 
 
-
-
     /**
      * Abstract base builder class.
      * Contains common configurations.
@@ -29,7 +27,7 @@ public class CompileTestBuilder {
         protected final CompileTestConfiguration compileTestConfiguration;
 
         protected BasicBuilder(CompileTestConfiguration compileTestConfiguration) {
-            this.compileTestConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            this.compileTestConfiguration = compileTestConfiguration;
         }
 
         /**
@@ -38,8 +36,9 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T compilationShouldSucceed() {
-            compileTestConfiguration.setCompilationShouldSucceed(true);
-            return createNextInstance(compileTestConfiguration);
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.setCompilationShouldSucceed(true);
+            return createNextInstance(nextConfiguration);
         }
 
         /**
@@ -48,8 +47,9 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T compilationShouldFail() {
-            compileTestConfiguration.setCompilationShouldSucceed(false);
-            return createNextInstance(compileTestConfiguration);
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.setCompilationShouldSucceed(false);
+            return createNextInstance(nextConfiguration);
         }
 
 
@@ -60,11 +60,11 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T addWarningChecks(String... warningChecks) {
-
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (warningChecks != null) {
-                compileTestConfiguration.addWarningMessageCheck(warningChecks);
+                nextConfiguration.addWarningMessageCheck(warningChecks);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
 
         }
 
@@ -76,10 +76,11 @@ public class CompileTestBuilder {
          */
         public T addMandatoryWarningChecks(String... mandatoryWarningChecks) {
 
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (mandatoryWarningChecks != null) {
-                compileTestConfiguration.addMandatoryWarningMessageCheck(mandatoryWarningChecks);
+                nextConfiguration.addMandatoryWarningMessageCheck(mandatoryWarningChecks);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
 
         }
 
@@ -91,10 +92,11 @@ public class CompileTestBuilder {
          */
         public T addErrorChecks(String... errorChecksToSet) {
 
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (errorChecksToSet != null) {
-                compileTestConfiguration.addErrorMessageCheck(errorChecksToSet);
+                nextConfiguration.addErrorMessageCheck(errorChecksToSet);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
 
         }
 
@@ -106,10 +108,11 @@ public class CompileTestBuilder {
          */
         public T addNoteChecks(String... noteChecksToSet) {
 
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (noteChecksToSet != null) {
-                compileTestConfiguration.addNoteMessageCheck(noteChecksToSet);
+                nextConfiguration.addNoteMessageCheck(noteChecksToSet);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
 
         }
 
@@ -137,8 +140,11 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T addGeneratedFileObjectExistsCheck(JavaFileManager.Location location, String packageName, String relativeName, FileObject expectedFileObject) {
-            compileTestConfiguration.addExpectedGeneratedFileObjectCheck(location, packageName, relativeName, expectedFileObject);
-            return createNextInstance(compileTestConfiguration);
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.addExpectedGeneratedFileObjectCheck(location, packageName, relativeName, expectedFileObject);
+            return createNextInstance(nextConfiguration);
+
         }
 
         /**
@@ -152,8 +158,11 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T addGeneratedFileObjectExistsCheck(JavaFileManager.Location location, String packageName, String relativeName, GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher) {
-            compileTestConfiguration.addExpectedGeneratedFileObjectCheck(location, packageName, relativeName, generatedFileObjectMatcher);
-            return createNextInstance(compileTestConfiguration);
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.addExpectedGeneratedFileObjectCheck(location, packageName, relativeName, generatedFileObjectMatcher);
+            return createNextInstance(nextConfiguration);
+
         }
 
         /**
@@ -179,8 +188,11 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T addGeneratedJavaFileObjectExistsCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, JavaFileObject expectedJavaFileObject) {
-            compileTestConfiguration.addExpectedGeneratedJavaFileObjectCheck(location, className, kind, expectedJavaFileObject);
-            return createNextInstance(compileTestConfiguration);
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.addExpectedGeneratedJavaFileObjectCheck(location, className, kind, expectedJavaFileObject);
+            return createNextInstance(nextConfiguration);
+
         }
 
         /**
@@ -194,8 +206,11 @@ public class CompileTestBuilder {
          * @return the next builder instance
          */
         public T addGeneratedJavaFileObjectExistsCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, GeneratedFileObjectMatcher<JavaFileObject> generatedJavaFileObjectCheck) {
-            compileTestConfiguration.addExpectedGeneratedJavaFileObjectCheck(location, className, kind, generatedJavaFileObjectCheck);
-            return createNextInstance(compileTestConfiguration);
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.addExpectedGeneratedJavaFileObjectCheck(location, className, kind, generatedJavaFileObjectCheck);
+            return createNextInstance(nextConfiguration);
+
         }
 
 
@@ -250,34 +265,53 @@ public class CompileTestBuilder {
         }
 
         /**
-         * Adds processors
+         * Adds processors.
          *
-         * @param processors
+         * @param processorTypes
          * @return
          */
-        public CompileTimeTestBuilder useProcessors(Processor... processors) {
-            if (processors != null) {
-                compileTestConfiguration.addProcessors(processors);
+        public CompileTimeTestBuilder useProcessors(Class<? extends Processor>... processorTypes) {
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            if (processorTypes != null) {
+                nextConfiguration.addProcessorTypes(processorTypes);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
+
         }
 
-        public CompileTimeTestBuilder useProcessorAndExpectException(Processor processor, Class<? extends Throwable> exception) {
+        /**
+         * Adds processors and links them with an expected exception check.
+         * Be aware that sharing a processor instance between tests might lead to undetermined behavior!!
+         * <p>
+         * This method might be removed soon due to the potential issues.
+         *
+         * @param processor
+         * @param exception
+         * @return
+         */
+        public CompileTimeTestBuilder useProcessorAndExpectException(Class<? extends Processor> processor, Class<? extends Throwable> exception) {
+
             if (processor == null) {
                 throw new IllegalArgumentException("Passed processor must not be null");
             }
             if (exception == null) {
                 throw new IllegalArgumentException("Passed exception must not be null");
             }
-            compileTestConfiguration.addProcessorWithExpectedException(processor, exception);
-            return createNextInstance(compileTestConfiguration);
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
+            nextConfiguration.addProcessorWithExpectedException(processor, exception);
+            return createNextInstance(nextConfiguration);
+
         }
 
         public CompileTimeTestBuilder addSources(JavaFileObject... sources) {
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (sources != null) {
-                compileTestConfiguration.addSourceFiles(sources);
+                nextConfiguration.addSourceFiles(sources);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
+
         }
 
         protected CompileTimeTestBuilder createNextInstance(CompileTestConfiguration compileTestConfiguration) {
@@ -303,11 +337,13 @@ public class CompileTestBuilder {
                 throw new IllegalArgumentException("passed processor must not be null!");
             }
 
-            // remove existing processor
-            compileTestConfiguration.getProcessors().clear();
-            compileTestConfiguration.addProcessors(processor);
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
 
-            return createNextInstance(compileTestConfiguration);
+            // remove existing processor
+            nextConfiguration.getProcessors().clear();
+            nextConfiguration.addProcessors(processor);
+
+            return createNextInstance(nextConfiguration);
         }
 
         /**
@@ -325,11 +361,13 @@ public class CompileTestBuilder {
                 throw new IllegalArgumentException("passed unitTestProcessor must not be null!");
             }
 
-            // remove existing processor
-            compileTestConfiguration.getProcessors().clear();
-            compileTestConfiguration.addProcessors(new UnitTestAnnotationProcessorClass(unitTestProcessor));
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
 
-            return createNextInstance(compileTestConfiguration);
+            // remove existing processor
+            nextConfiguration.getProcessors().clear();
+            nextConfiguration.addProcessors(new UnitTestAnnotationProcessorClass(unitTestProcessor));
+
+            return createNextInstance(nextConfiguration);
         }
 
 
@@ -348,30 +386,38 @@ public class CompileTestBuilder {
                 throw new IllegalArgumentException("passed source file must not be null!");
             }
 
-            // clear existing sources
-            compileTestConfiguration.getSourceFiles().clear();
-            compileTestConfiguration.addSourceFiles(source);
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
 
-            return createNextInstance(compileTestConfiguration);
+            // clear existing sources
+            nextConfiguration.getSourceFiles().clear();
+            nextConfiguration.addSourceFiles(source);
+
+            return createNextInstance(nextConfiguration);
+
         }
 
         /**
          * Sets an expected exception thrown in the unit test case.
          */
         public UnitTestBuilder expectedThrownException(Class<? extends Throwable> expectedException) {
+
+            CompileTestConfiguration nextConfiguration = CompileTestConfiguration.cloneConfiguration(compileTestConfiguration);
             if (expectedException != null) {
-                compileTestConfiguration.setExpectedThrownException(expectedException);
+                nextConfiguration.setExpectedThrownException(expectedException);
             }
-            return createNextInstance(compileTestConfiguration);
+            return createNextInstance(nextConfiguration);
+
         }
 
 
         public void testCompilation() {
+
             if (compileTestConfiguration.getProcessors().size() == 0) {
                 throw new IllegalArgumentException("At least one processor has to be added to the compiler test configuration");
             }
 
             super.testCompilation();
+
         }
 
         /**

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/JavaFileObjectUtils.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/JavaFileObjectUtils.java
@@ -10,6 +10,7 @@ import java.io.StringBufferInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Random;
 
 /**
  * Utility class to create JavaFileObjects and therefore also FileObjects.
@@ -168,7 +169,7 @@ public class JavaFileObjectUtils {
 
 
     /**
-     * Read a java source file from reosurces.
+     * Read a java source file from string.
      *
      * @param location the location
      * @param content  content of the file
@@ -185,6 +186,35 @@ public class JavaFileObjectUtils {
         }
 
         return new JavaSourceFromString(location, content);
+    }
+
+    /**
+     * Read a java source file from resources.
+     * This one works great if you don't rely on the location, f.e. in case of comparision.
+     *
+     * @param content content of the file
+     * @return
+     */
+    public static SimpleJavaFileObject readFromString(String content) {
+
+        // create a random location
+        String location = "string_" + getRandomString(6);
+
+        return readFromString(location, content);
+    }
+
+    protected static String getRandomString(int length) {
+
+        int leftLimit = 97; // letter 'a'
+        int rightLimit = 122; // letter 'z'
+        Random random = new Random();
+        StringBuilder buffer = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            int randomLimitedInt = leftLimit + (int)
+                    (random.nextFloat() * (rightLimit - leftLimit + 1));
+            buffer.append((char) randomLimitedInt);
+        }
+        return buffer.toString();
     }
 
     /**

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/JavaFileObjectUtils.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/JavaFileObjectUtils.java
@@ -14,7 +14,6 @@ import java.net.URL;
 /**
  * Utility class to create JavaFileObjects and therefore also FileObjects.
  * These files can be used for comparision or as source files during compilation.
- *
  */
 public class JavaFileObjectUtils {
 
@@ -169,7 +168,7 @@ public class JavaFileObjectUtils {
 
 
     /**
-     * Read a java source file from resurces.
+     * Read a java source file from reosurces.
      *
      * @param location the location
      * @param content  content of the file

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/AnnotationProcessorWrapper.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/AnnotationProcessorWrapper.java
@@ -140,7 +140,7 @@ public final class AnnotationProcessorWrapper implements Processor {
         }
 
         try {
-            return new AnnotationProcessorWrapper(processorTypeToWrap.newInstance());
+            return new AnnotationProcessorWrapper(processorTypeToWrap.getDeclaredConstructor().newInstance());
         } catch (Exception e) {
             throw new IllegalArgumentException("Cannot instantiate passed processor Class '" + processorTypeToWrap.getCanonicalName() + "'. Make sure that a NoArg constructor exists and is accessible.", e);
         }
@@ -158,7 +158,7 @@ public final class AnnotationProcessorWrapper implements Processor {
         }
 
         try {
-            return new AnnotationProcessorWrapper(processorTypeToWrap.newInstance(), expectedThrownException);
+            return new AnnotationProcessorWrapper(processorTypeToWrap.getDeclaredConstructor().newInstance(), expectedThrownException);
         } catch (Exception e) {
             throw new IllegalArgumentException(" instantiate passed processor Class '" + processorTypeToWrap.getCanonicalName() + "'. Make sure that a NoArg constructor exists and is accessible.", e);
         }

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTest.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTest.java
@@ -67,7 +67,7 @@ public class CompileTest {
         for (CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectCheck : this.compileTestConfiguration.getGeneratedJavaFileObjectChecks()) {
 
             if (!compilationResult.getCompileTestFileManager().existsExpectedJavaFileObject(generatedJavaFileObjectCheck.getLocation(), generatedJavaFileObjectCheck.getClassName(), generatedJavaFileObjectCheck.getKind())) {
-                AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") doesn't exist.\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview());
+                AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") doesn't exist.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
             } else {
 
                 try {
@@ -81,7 +81,7 @@ public class CompileTest {
                                 foundJavaFileObject.openInputStream(),
                                 generatedJavaFileObjectCheck.getExpectedJavaFileObject().openInputStream())) {
 
-                            AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") exists but doesn't match expected JavaFileObject.\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview());
+                            AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") exists but doesn't match expected JavaFileObject.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
 
                         }
 
@@ -91,7 +91,7 @@ public class CompileTest {
                     if (generatedJavaFileObjectCheck.getGeneratedFileObjectMatcher() != null) {
 
                         if (!generatedJavaFileObjectCheck.getGeneratedFileObjectMatcher().check(foundJavaFileObject)) {
-                            AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") exists but doesn't match passed GeneratedFileObjectMatcher.\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview());
+                            AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") exists but doesn't match passed GeneratedFileObjectMatcher.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
                         }
 
                     }
@@ -109,7 +109,7 @@ public class CompileTest {
         for (CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectCheck : this.compileTestConfiguration.getGeneratedFileObjectChecks()) {
 
             if (!compilationResult.getCompileTestFileManager().existsExpectedFileObject(generatedFileObjectCheck.getLocation(), generatedFileObjectCheck.getPackageName(), generatedFileObjectCheck.getRelativeName())) {
-                AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") doesn't exist.\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview());
+                AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") doesn't exist.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
             } else {
 
                 try {
@@ -123,7 +123,7 @@ public class CompileTest {
                                 foundFileObject.openInputStream(),
                                 generatedFileObjectCheck.getExpectedFileObject().openInputStream())) {
 
-                            AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") exists but doesn't match expected FileObject.\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview());
+                            AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") exists but doesn't match expected FileObject.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
 
                         }
 
@@ -133,7 +133,7 @@ public class CompileTest {
                     if (generatedFileObjectCheck.getGeneratedFileObjectMatcher() != null) {
 
                         if (!generatedFileObjectCheck.getGeneratedFileObjectMatcher().check(foundFileObject)) {
-                            AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") exists but doesn't match passed GeneratedFileObjectMatcher.\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview());
+                            AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") exists but doesn't match passed GeneratedFileObjectMatcher.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
                         }
 
                     }
@@ -246,5 +246,8 @@ public class CompileTest {
 
     }
 
+    private static String getDebugOutput(CompilationResult compilationResult, CompileTestConfiguration compileTestConfiguration) {
+        return "\n-------------------------------\n-- GENERATED FILEOBJECTS: \n-------------------------------\n" + compilationResult.getCompileTestFileManager().getGeneratedFileOverview() + "\n-------------------------------\n-- COMPILE TEST CONFIGURATION: \n-------------------------------\n" + compileTestConfiguration.toString();
+    }
 
 }

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTest.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTest.java
@@ -18,6 +18,22 @@ import java.util.Set;
  */
 public class CompileTest {
 
+    // Messages
+    public final static String MESSAGE_COMPILATION_SHOULD_SUCCEED_AND_ERROR_MESSAGE_EXPECTED = "Test configuration error : Compilation should succeed but error messages is expected too !!!";
+    public final static String MESSAGE_COMPILATION_SHOULD_HAVE_SUCCEEDED_BUT_FAILED = "Compilation should have succeeded but failed";
+    public final static String MESSAGE_COMPILATION_SHOULD_HAVE_FAILED_BUT_SUCCEEDED = "Compilation should have failed but succeeded";
+
+    public final static String MESSAGE_JFO_DOESNT_EXIST = "Expected generated JavaFileObject (%s) doesn't exist.\n%s";
+    public final static String MESSAGE_JFO_EXISTS_BUT_DOESNT_MATCH_FO = "Expected generated JavaFileObject (%s) exists but doesn't match expected JavaFileObject.\n%s";
+    public final static String MESSAGE_JFO_EXISTS_BUT_DOESNT_MATCH_MATCHER = "Expected generated JavaFileObject (%s) exists but doesn't match passed GeneratedFileObjectMatcher.\n%s";
+
+    public final static String MESSAGE_FO_DOESNT_EXIST = "Expected generated FileObject (%s) doesn't exist.\n%s";
+    public final static String MESSAGE_FO_EXISTS_BUT_DOESNT_MATCH_FO = "Expected generated FileObject (%s) exists but doesn't match expected FileObject.\n%s";
+    public final static String MESSAGE_FO_EXISTS_BUT_DOESNT_MATCH_MATCHER = "Expected generated FileObject (%s) exists but doesn't match passed GeneratedFileObjectMatcher.\n%s";
+
+    public final static String MESSAGE_PROCESSOR_HASNT_BEEN_APPLIED = "Annotation processor %s hasn't been applied on a class";
+    public final static String MESSAGE_HAVENT_FOUND_MESSSAGE = "Haven't found expected message string '%s' of kind %s. Got messages %s";
+
     private final CompileTestConfiguration compileTestConfiguration;
 
     /**
@@ -45,14 +61,14 @@ public class CompileTest {
         if (compileTestConfiguration.getCompilationShouldSucceed() != null
                 && compileTestConfiguration.getCompilationShouldSucceed()
                 && compileTestConfiguration.getErrorMessageCheck().size() > 0) {
-            throw new InvalidTestConfigurationException("Test configuration error : Compilation should succeed but error messages is expected too !!!");
+            throw new InvalidTestConfigurationException(MESSAGE_COMPILATION_SHOULD_SUCCEED_AND_ERROR_MESSAGE_EXPECTED);
         }
 
 
         // Check if compilation succeeded
         if (compileTestConfiguration.getCompilationShouldSucceed() != null && !compileTestConfiguration.getCompilationShouldSucceed().equals(compilationResult.getCompilationSucceeded())) {
 
-            AssertionSpiServiceLocator.locate().fail(compileTestConfiguration.getCompilationShouldSucceed() ? "Compilation should have succeeded but failed" : "Compilation should have failed but succeeded");
+            AssertionSpiServiceLocator.locate().fail(compileTestConfiguration.getCompilationShouldSucceed() ? MESSAGE_COMPILATION_SHOULD_HAVE_SUCCEEDED_BUT_FAILED : MESSAGE_COMPILATION_SHOULD_HAVE_FAILED_BUT_SUCCEEDED);
 
         }
 
@@ -67,7 +83,7 @@ public class CompileTest {
         for (CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectCheck : this.compileTestConfiguration.getGeneratedJavaFileObjectChecks()) {
 
             if (!compilationResult.getCompileTestFileManager().existsExpectedJavaFileObject(generatedJavaFileObjectCheck.getLocation(), generatedJavaFileObjectCheck.getClassName(), generatedJavaFileObjectCheck.getKind())) {
-                AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") doesn't exist.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
+                AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_JFO_DOESNT_EXIST, getJavaFileObjectInfoString(generatedJavaFileObjectCheck), getDebugOutput(compilationResult, compileTestConfiguration)));
             } else {
 
                 try {
@@ -81,7 +97,7 @@ public class CompileTest {
                                 foundJavaFileObject.openInputStream(),
                                 generatedJavaFileObjectCheck.getExpectedJavaFileObject().openInputStream())) {
 
-                            AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") exists but doesn't match expected JavaFileObject.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
+                            AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_JFO_EXISTS_BUT_DOESNT_MATCH_FO, getJavaFileObjectInfoString(generatedJavaFileObjectCheck), getDebugOutput(compilationResult, compileTestConfiguration)));
 
                         }
 
@@ -91,7 +107,7 @@ public class CompileTest {
                     if (generatedJavaFileObjectCheck.getGeneratedFileObjectMatcher() != null) {
 
                         if (!generatedJavaFileObjectCheck.getGeneratedFileObjectMatcher().check(foundJavaFileObject)) {
-                            AssertionSpiServiceLocator.locate().fail("Generated JavaFileObject (" + generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind() + ") exists but doesn't match passed GeneratedFileObjectMatcher.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
+                            AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_JFO_EXISTS_BUT_DOESNT_MATCH_MATCHER, getJavaFileObjectInfoString(generatedJavaFileObjectCheck), getDebugOutput(compilationResult, compileTestConfiguration)));
                         }
 
                     }
@@ -109,7 +125,7 @@ public class CompileTest {
         for (CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectCheck : this.compileTestConfiguration.getGeneratedFileObjectChecks()) {
 
             if (!compilationResult.getCompileTestFileManager().existsExpectedFileObject(generatedFileObjectCheck.getLocation(), generatedFileObjectCheck.getPackageName(), generatedFileObjectCheck.getRelativeName())) {
-                AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") doesn't exist.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
+                AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_FO_DOESNT_EXIST, getFileObjectInfoString(generatedFileObjectCheck), getDebugOutput(compilationResult, compileTestConfiguration)));
             } else {
 
                 try {
@@ -123,7 +139,7 @@ public class CompileTest {
                                 foundFileObject.openInputStream(),
                                 generatedFileObjectCheck.getExpectedFileObject().openInputStream())) {
 
-                            AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") exists but doesn't match expected FileObject.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
+                            AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_FO_EXISTS_BUT_DOESNT_MATCH_FO, getFileObjectInfoString(generatedFileObjectCheck), getDebugOutput(compilationResult, compileTestConfiguration)));
 
                         }
 
@@ -133,7 +149,7 @@ public class CompileTest {
                     if (generatedFileObjectCheck.getGeneratedFileObjectMatcher() != null) {
 
                         if (!generatedFileObjectCheck.getGeneratedFileObjectMatcher().check(foundFileObject)) {
-                            AssertionSpiServiceLocator.locate().fail("Generated FileObject (" + generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName() + ") exists but doesn't match passed GeneratedFileObjectMatcher.\n" + getDebugOutput(compilationResult, compileTestConfiguration));
+                            AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_FO_EXISTS_BUT_DOESNT_MATCH_MATCHER, getFileObjectInfoString(generatedFileObjectCheck), getDebugOutput(compilationResult, compileTestConfiguration)));
                         }
 
                     }
@@ -148,6 +164,14 @@ public class CompileTest {
 
         }
 
+    }
+
+    protected static String getJavaFileObjectInfoString(CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectCheck) {
+        return generatedJavaFileObjectCheck.getLocation() + "; " + generatedJavaFileObjectCheck.getClassName() + "; " + generatedJavaFileObjectCheck.getKind();
+    }
+
+    protected static String getFileObjectInfoString(CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectCheck) {
+        return generatedFileObjectCheck.getLocation() + "; " + generatedFileObjectCheck.getPackageName() + "; " + generatedFileObjectCheck.getRelativeName();
     }
 
     /**
@@ -189,7 +213,7 @@ public class CompileTest {
                 }
             }
 
-            AssertionSpiServiceLocator.locate().fail("Annotation processor " + processor.getWrappedProcessor().getClass().getCanonicalName() + " hasn't been applied on a class");
+            AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_PROCESSOR_HASNT_BEEN_APPLIED, processor.getWrappedProcessor().getClass().getCanonicalName()));
 
         }
 
@@ -219,7 +243,7 @@ public class CompileTest {
             }
 
             // Not found ==> assertion fails
-            AssertionSpiServiceLocator.locate().fail("Haven't found expected message string '" + messageToCheck + "' of kind " + kind.name() + ". Got messages " + messages.toString());
+            AssertionSpiServiceLocator.locate().fail(String.format(MESSAGE_HAVENT_FOUND_MESSSAGE, messageToCheck, kind.name(), messages.toString()));
 
         }
 

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestConfiguration.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestConfiguration.java
@@ -34,6 +34,49 @@ public class CompileTestConfiguration {
         }
 
         @Override
+        public int hashCode() {
+            return (processorType != null ? processorType.hashCode() : 0)
+                    + (throwable != null ? throwable.hashCode() : 0);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+
+            if (obj != null && ProcessorWithExpectedException.class.isAssignableFrom(obj.getClass())) {
+
+                ProcessorWithExpectedException otherObj = (ProcessorWithExpectedException) obj;
+
+                // compare processorType
+                if ((this.getProcessorType() == null && otherObj.getProcessorType() != null)
+                        || (this.getProcessorType() != null && otherObj.getProcessorType() == null)) {
+
+                    return false;
+
+                } else if ((this.getProcessorType() != null && otherObj.getProcessorType() != null)) {
+                    if (!this.getProcessorType().equals(otherObj.getProcessorType())) {
+                        return false;
+                    }
+                }
+
+                // compare throwable
+                if ((this.getThrowable() == null && otherObj.getThrowable() != null)
+                        || (this.getThrowable() != null && otherObj.getThrowable() == null)) {
+
+                    return false;
+
+                } else if ((this.getThrowable() != null && otherObj.getThrowable() != null)) {
+                    if (!this.getThrowable().equals(otherObj.getThrowable())) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
         public String toString() {
             return "ProcessorWithExpectedException{" +
                     "\n\t\tprocessorType=" + processorType +
@@ -93,6 +136,89 @@ public class CompileTestConfiguration {
         }
 
         @Override
+        public int hashCode() {
+            return (this.location != null ? this.location.hashCode() : 0)
+                    + (className != null ? className.hashCode() : 0)
+                    + (kind != null ? kind.hashCode() : 0)
+                    + (expectedJavaFileObject != null ? expectedJavaFileObject.hashCode() : 0)
+                    + (generatedFileObjectMatcher != null ? generatedFileObjectMatcher.hashCode() : 0);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+
+            if (obj != null && GeneratedJavaFileObjectCheck.class.isAssignableFrom(obj.getClass())) {
+
+                GeneratedJavaFileObjectCheck otherObj = (GeneratedJavaFileObjectCheck) obj;
+
+                // compare location
+                if ((this.getLocation() == null && otherObj.getLocation() != null)
+                        || (this.getLocation() != null && otherObj.getLocation() == null)) {
+
+                    return false;
+
+                } else if ((this.getLocation() != null && otherObj.getLocation() != null)) {
+                    if (!this.getLocation().equals(otherObj.getLocation())) {
+                        return false;
+                    }
+                }
+
+                // compare className
+                if ((this.getClassName() == null && otherObj.getClassName() != null)
+                        || (this.getClassName() != null && otherObj.getClassName() == null)) {
+
+                    return false;
+
+                } else if ((this.getClassName() != null && otherObj.getClassName() != null)) {
+                    if (!this.getClassName().equals(otherObj.getClassName())) {
+                        return false;
+                    }
+                }
+
+                // compare kind
+                if ((this.getKind() == null && otherObj.getKind() != null)
+                        || (this.getKind() != null && otherObj.getKind() == null)) {
+
+                    return false;
+
+                } else if ((this.getKind() != null && otherObj.getKind() != null)) {
+                    if (!this.getKind().equals(otherObj.getKind())) {
+                        return false;
+                    }
+                }
+
+                // compare expectedJavaFileObject
+                if ((this.getExpectedJavaFileObject() == null && otherObj.getExpectedJavaFileObject() != null)
+                        || (this.getExpectedJavaFileObject() != null && otherObj.getExpectedJavaFileObject() == null)) {
+
+                    return false;
+
+                } else if ((this.getExpectedJavaFileObject() != null && otherObj.getExpectedJavaFileObject() != null)) {
+                    if (!this.getExpectedJavaFileObject().equals(otherObj.getExpectedJavaFileObject())) {
+                        return false;
+                    }
+                }
+
+                // compare generatedFileObjectMatcher
+                if ((this.getGeneratedFileObjectMatcher() == null && otherObj.getGeneratedFileObjectMatcher() != null)
+                        || (this.getGeneratedFileObjectMatcher() != null && otherObj.getGeneratedFileObjectMatcher() == null)) {
+
+                    return false;
+
+                } else if ((this.getGeneratedFileObjectMatcher() != null && otherObj.getGeneratedFileObjectMatcher() != null)) {
+                    if (!this.getGeneratedFileObjectMatcher().equals(otherObj.getGeneratedFileObjectMatcher())) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+
+        @Override
         public String toString() {
             return "GeneratedJavaFileObjectCheck{" +
                     "\n\t\tlocation=" + location +
@@ -111,6 +237,7 @@ public class CompileTestConfiguration {
         private final String packageName;
         private final String relativeName;
 
+        // either expectedFileObject or generatedFileObjectMatcher may be set not null
         private final FileObject expectedFileObject;
         private final GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher;
 
@@ -156,6 +283,88 @@ public class CompileTestConfiguration {
         }
 
         @Override
+        public int hashCode() {
+            return (this.location != null ? this.location.hashCode() : 0)
+                    + (packageName != null ? packageName.hashCode() : 0)
+                    + (relativeName != null ? relativeName.hashCode() : 0)
+                    + (expectedFileObject != null ? expectedFileObject.hashCode() : 0)
+                    + (generatedFileObjectMatcher != null ? generatedFileObjectMatcher.hashCode() : 0);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+
+            if (obj != null && GeneratedFileObjectCheck.class.isAssignableFrom(obj.getClass())) {
+
+                GeneratedFileObjectCheck otherObj = (GeneratedFileObjectCheck) obj;
+
+                // compare location
+                if ((this.getLocation() == null && otherObj.getLocation() != null)
+                        || (this.getLocation() != null && otherObj.getLocation() == null)) {
+
+                    return false;
+
+                } else if ((this.getLocation() != null && otherObj.getLocation() != null)) {
+                    if (!this.getLocation().equals(otherObj.getLocation())) {
+                        return false;
+                    }
+                }
+
+                // compare packageName
+                if ((this.getPackageName() == null && otherObj.getPackageName() != null)
+                        || (this.getPackageName() != null && otherObj.getPackageName() == null)) {
+
+                    return false;
+
+                } else if ((this.getPackageName() != null && otherObj.getPackageName() != null)) {
+                    if (!this.getPackageName().equals(otherObj.getPackageName())) {
+                        return false;
+                    }
+                }
+
+                // compare relativeName
+                if ((this.getRelativeName() == null && otherObj.getRelativeName() != null)
+                        || (this.getRelativeName() != null && otherObj.getRelativeName() == null)) {
+
+                    return false;
+
+                } else if ((this.getRelativeName() != null && otherObj.getRelativeName() != null)) {
+                    if (!this.getRelativeName().equals(otherObj.getRelativeName())) {
+                        return false;
+                    }
+                }
+
+                // compare expectedFileObject
+                if ((this.getExpectedFileObject() == null && otherObj.getExpectedFileObject() != null)
+                        || (this.getExpectedFileObject() != null && otherObj.getExpectedFileObject() == null)) {
+
+                    return false;
+
+                } else if ((this.getExpectedFileObject() != null && otherObj.getExpectedFileObject() != null)) {
+                    if (!this.getExpectedFileObject().equals(otherObj.getExpectedFileObject())) {
+                        return false;
+                    }
+                }
+
+                // compare generatedFileObjectMatcher
+                if ((this.getGeneratedFileObjectMatcher() == null && otherObj.getGeneratedFileObjectMatcher() != null)
+                        || (this.getGeneratedFileObjectMatcher() != null && otherObj.getGeneratedFileObjectMatcher() == null)) {
+
+                    return false;
+
+                } else if ((this.getGeneratedFileObjectMatcher() != null && otherObj.getGeneratedFileObjectMatcher() != null)) {
+                    if (!this.getGeneratedFileObjectMatcher().equals(otherObj.getGeneratedFileObjectMatcher())) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
         public String toString() {
             return "GeneratedFileObjectCheck{" +
                     "\n\t\tlocation=" + location +
@@ -189,6 +398,11 @@ public class CompileTestConfiguration {
     private final Set<ProcessorWithExpectedException> processorsWithExpectedExceptions = new HashSet<ProcessorWithExpectedException>();
 
     /**
+     * This is a cache for all wrapped processors and must be reset after processors are added.
+     */
+    private Set<AnnotationProcessorWrapper> wrappedProcessors = null;
+
+    /**
      * Global processor independant expected exceptions.
      */
     private Class<? extends Throwable> expectedThrownException = null;
@@ -199,10 +413,10 @@ public class CompileTestConfiguration {
     private Boolean compilationShouldSucceed;
 
     // message checks by severity
+    private final Set<String> noteMessageCheck = new HashSet<String>();
     private final Set<String> warningMessageCheck = new HashSet<String>();
     private final Set<String> mandatoryWarningMessageCheck = new HashSet<String>();
     private final Set<String> errorMessageCheck = new HashSet<String>();
-    private final Set<String> noteMessageCheck = new HashSet<String>();
 
 
     /**
@@ -262,9 +476,14 @@ public class CompileTestConfiguration {
     /**
      * This method should only be used for unit compile tests.
      * Sharing instance between test runs can cause undeterministic behavior.
+     *
      * @param processors
      */
     public void addProcessors(Processor... processors) {
+
+        // reset cache
+        this.wrappedProcessors = null;
+
         if (processors != null) {
             this.processors.addAll(Arrays.asList(processors));
             this.processors.remove(null);
@@ -272,6 +491,10 @@ public class CompileTestConfiguration {
     }
 
     public void addProcessorTypes(Class<? extends Processor>... processorTypes) {
+
+        // reset cache
+        this.wrappedProcessors = null;
+
         if (processorTypes != null) {
             this.processorTypes.addAll(Arrays.asList(processorTypes));
             this.processorTypes.remove(null);
@@ -279,7 +502,12 @@ public class CompileTestConfiguration {
     }
 
     public void addProcessorWithExpectedException(Class<? extends Processor> processorType, Class<? extends Throwable> e) {
+
+        // reset cache
+        this.wrappedProcessors = null;
+
         this.processorsWithExpectedExceptions.add(new ProcessorWithExpectedException(processorType, e));
+
     }
 
     public void addWarningMessageCheck(String... warningMessage) {
@@ -311,19 +539,19 @@ public class CompileTestConfiguration {
     }
 
 
-    public void addExpectedGeneratedJavaFileObjectCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, JavaFileObject javaFileObject) {
+    public void addGeneratedJavaFileObjectCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, JavaFileObject javaFileObject) {
         this.generatedJavaFileObjectChecks.add(new GeneratedJavaFileObjectCheck(location, className, kind, javaFileObject));
     }
 
-    public void addExpectedGeneratedJavaFileObjectCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, GeneratedFileObjectMatcher<JavaFileObject> generatedFileObjectMatcher) {
+    public void addGeneratedJavaFileObjectCheck(JavaFileManager.Location location, String className, JavaFileObject.Kind kind, GeneratedFileObjectMatcher<JavaFileObject> generatedFileObjectMatcher) {
         this.generatedJavaFileObjectChecks.add(new GeneratedJavaFileObjectCheck(location, className, kind, generatedFileObjectMatcher));
     }
 
-    public void addExpectedGeneratedFileObjectCheck(JavaFileManager.Location location, String packageName, String relativeName, FileObject javaFileObject) {
+    public void addGeneratedFileObjectCheck(JavaFileManager.Location location, String packageName, String relativeName, FileObject javaFileObject) {
         this.generatedFileObjectChecks.add(new GeneratedFileObjectCheck(location, packageName, relativeName, javaFileObject));
     }
 
-    public void addExpectedGeneratedFileObjectCheck(JavaFileManager.Location location, String packageName, String relativeName, GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher) {
+    public void addGeneratedFileObjectCheck(JavaFileManager.Location location, String packageName, String relativeName, GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher) {
         this.generatedFileObjectChecks.add(new GeneratedFileObjectCheck(location, packageName, relativeName, generatedFileObjectMatcher));
     }
 
@@ -347,7 +575,14 @@ public class CompileTestConfiguration {
         return processorsWithExpectedExceptions;
     }
 
+
     public Set<AnnotationProcessorWrapper> getWrappedProcessors() {
+
+        // return cached wrapped processors if available
+        if (wrappedProcessors != null) {
+            return wrappedProcessors;
+        }
+
 
         Set<AnnotationProcessorWrapper> wrappedProcessors = new HashSet<AnnotationProcessorWrapper>();
 
@@ -382,6 +617,9 @@ public class CompileTestConfiguration {
             wrappedProcessors.add(AnnotationProcessorWrapper.wrapProcessor(processor.processorType, processor.throwable != null ? processor.throwable : expectedThrownException));
 
         }
+
+        // save cached wrapped processors
+        this.wrappedProcessors = wrappedProcessors;
 
         return wrappedProcessors;
 

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestFileManager.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestFileManager.java
@@ -28,7 +28,7 @@ import java.util.Map;
 public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
 
 
-    public class FileObjectCache<T extends FileObject> {
+    public static class FileObjectCache<T extends FileObject> {
 
         final Map<URI, T> fileObjectCache = new HashMap<URI, T>();
 
@@ -53,8 +53,8 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
     }
 
 
-    final FileObjectCache<JavaFileObject> generatedJavaFileObjectCache = new FileObjectCache<JavaFileObject>();
-    final FileObjectCache<FileObject> generatedFileObjectCache = new FileObjectCache<FileObject>();
+    private final FileObjectCache<JavaFileObject> generatedJavaFileObjectCache = new FileObjectCache<JavaFileObject>();
+    private final FileObjectCache<FileObject> generatedFileObjectCache = new FileObjectCache<FileObject>();
 
 
     public CompileTestFileManager(StandardJavaFileManager standardJavaFileManager) {
@@ -154,7 +154,7 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
 
 
         stringBuilder
-                .append("GENERATED FILES OVERVIEW:{\n")
+                .append("{\n")
                 .append("  'GENERATED JAVA FILE OBJECTS' : ")
                 .append(getGeneratedJavaFileObjectOverview())
                 .append(",\n  'GENERATED FILE OBJECTS' :")
@@ -204,7 +204,7 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
                 try {
                     String content = (String) entry.getValue().getCharContent(false);
 
-                    stringBuilder.append("    '" + entry.getKey().toString() + "' : '" + (content.length() < 100 ? content : content.substring(0, 97) + "...") + "',\n");
+                    stringBuilder.append("    '" + entry.getKey().toString() + "' : '" + (content.length() < 500 ? content : content.substring(0, 497) + "...") + "',\n");
 
                 } catch (IOException e) {
                     // ignore - can't happen
@@ -264,7 +264,7 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
     }
 
 
-    public class InMemoryOutputJavaFileObject extends SimpleJavaFileObject implements OutputStreamCallback {
+    public static class InMemoryOutputJavaFileObject extends SimpleJavaFileObject implements OutputStreamCallback {
 
         private byte[] content = new byte[0];
 

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestUtilities.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestUtilities.java
@@ -7,7 +7,8 @@ import javax.annotation.processing.Processor;
  */
 public class CompileTestUtilities {
 
-    private final static String TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED = "!!!--- ANNOTATION PROCESSOR (%s) WAS APPPLIED ---!!!";
+    protected static final String ANONYMOUS_CLASS = "ANONYMOUS CLASS<%s>";
+    protected final static String TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED = "!!!--- ANNOTATION PROCESSOR (%s)<#%s> WAS APPPLIED ---!!!";
 
     /**
      * Hidden constructor.
@@ -18,11 +19,22 @@ public class CompileTestUtilities {
 
     /**
      * Produces messages string depending on passed processor to check if processor has been applied.
+     *
      * @param processor the processor to create the message for
      * @return the message to check if processor has been applied
      */
-    public static String getAnnotationProcessorWasAppliedMessage (Processor processor) {
-        return String.format(TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED, processor.getClass().getCanonicalName());
+    public static String getAnnotationProcessorWasAppliedMessage(Processor processor) {
+        return String.format(TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED,
+                processor != null && processor.getClass() != null ? (
+                        processor.getClass().getCanonicalName() != null ?
+                                processor.getClass().getCanonicalName() :
+                                String.format(ANONYMOUS_CLASS,
+                                        Object.class.equals(processor.getClass().getSuperclass()) ?
+                                                Processor.class.getCanonicalName()
+                                                : processor.getClass().getSuperclass().getCanonicalName()
+                                )
+                ) : "",
+                processor!= null ? System.identityHashCode(processor): "NULL");
     }
 
 }

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/CompileTestBuilderTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/CompileTestBuilderTest.java
@@ -90,8 +90,7 @@ public class CompileTestBuilderTest {
 
         CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
                 .compilationTest()
-                .addWarningChecks("WARN1")
-                ;
+                .addWarningChecks("WARN1");
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration().getWarningMessageCheck(), Matchers.containsInAnyOrder("WARN1"));
 
@@ -222,22 +221,34 @@ public class CompileTestBuilderTest {
 
     }
 
+    private static class SimpleTestProcessor1 extends AbstractProcessor {
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+    }
+
+    private static class SimpleTestProcessor2 extends AbstractProcessor {
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+    }
 
     @Test
     public void test_useProcessors() {
 
-        Processor testProcessor1 = Mockito.mock(Processor.class);
-        Processor testProcessor2 = Mockito.mock(Processor.class);
+        Class<? extends Processor> testProcessor1 = SimpleTestProcessor1.class;
+        Class<? extends Processor> testProcessor2 = SimpleTestProcessor2.class;
 
         CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
                 .compilationTest()
                 .useProcessors(testProcessor1)
                 .useProcessors(testProcessor2)
-                .useProcessors(null)
-                .useProcessors();
+                .useProcessors((Class<? extends Processor>) null);
 
 
-        MatcherAssert.assertThat(builder.createCompileTestConfiguration().getProcessors(), Matchers.containsInAnyOrder(testProcessor1, testProcessor2));
+        MatcherAssert.assertThat(builder.createCompileTestConfiguration().getProcessorTypes(), Matchers.containsInAnyOrder(testProcessor1, testProcessor2));
 
 
     }
@@ -245,8 +256,8 @@ public class CompileTestBuilderTest {
     @Test
     public void test_useProcessorAndExpectException() {
 
-        Processor testProcessor1 = Mockito.mock(Processor.class);
-        Processor testProcessor2 = Mockito.mock(Processor.class);
+        Class<? extends Processor> testProcessor1 = SimpleTestProcessor1.class;
+        Class<? extends Processor> testProcessor2 = SimpleTestProcessor2.class;
 
         CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
                 .compilationTest()
@@ -330,17 +341,19 @@ public class CompileTestBuilderTest {
 
     }
 
+    private static class SimpleTestProcessor extends AbstractProcessor {
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void test_CompileTimeTestBuilder_useProcessorAndExpectException_addNullValuedException() {
 
         CompileTestBuilder.createCompileTestBuilder()
                 .compilationTest()
-                .useProcessorAndExpectException(new AbstractProcessor() {
-                    @Override
-                    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-                        return false;
-                    }
-                }, null);
+                .useProcessorAndExpectException(SimpleTestProcessor.class, null);
 
 
     }

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/CompileTestBuilderTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/CompileTestBuilderTest.java
@@ -1,5 +1,7 @@
 package io.toolisticon.compiletesting;
 
+import io.toolisticon.compiletesting.common.SimpleTestProcessor1;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor2;
 import io.toolisticon.compiletesting.impl.CompileTestConfiguration;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -26,7 +28,7 @@ public class CompileTestBuilderTest {
 
         JavaFileObject testSource = Mockito.mock(JavaFileObject.class);
         JavaFileObject expectedGeneratedSource = JavaFileObjectUtils.readFromString("Jupp.txt", "TATA!");
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .unitTest()
                 .useProcessor(
                         new UnitTestProcessor() {
@@ -51,9 +53,9 @@ public class CompileTestBuilderTest {
 
                             }
                         })
-                .addWarningChecks("WARNING")
-                .addMandatoryWarningChecks("MANDATORY_WARNING")
-                .addNoteChecks("NOTE")
+                .expectedWarningMessages("WARNING")
+                .expectedMandatoryWarningMessages("MANDATORY_WARNING")
+                .expectedNoteMessages("NOTE")
                 .compilationShouldSucceed()
                 .testCompilation();
 
@@ -66,7 +68,7 @@ public class CompileTestBuilderTest {
         JavaFileObject testSource = Mockito.mock(JavaFileObject.class);
         JavaFileObject expectedGeneratedSource = Mockito.mock(JavaFileObject.class);
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .unitTest()
                 .useProcessor(new UnitTestProcessor() {
                     @Override
@@ -77,7 +79,7 @@ public class CompileTestBuilderTest {
 
                     }
                 })
-                .addErrorChecks("ERROR")
+                .expectedErrorMessages("ERROR")
                 .compilationShouldFail()
                 .testCompilation();
 
@@ -88,22 +90,22 @@ public class CompileTestBuilderTest {
     @Test
     public void test_addWarningChecks() {
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
-                .addWarningChecks("WARN1");
+                .expectedWarningMessages("WARN1");
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration().getWarningMessageCheck(), Matchers.containsInAnyOrder("WARN1"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder2 = builder
-                .addWarningChecks("WARN2");
+        CompileTestBuilder.CompilationTestBuilder builder2 = builder
+                .expectedWarningMessages("WARN2");
 
         MatcherAssert.assertThat(builder2
                 .createCompileTestConfiguration()
                 .getWarningMessageCheck(), Matchers.containsInAnyOrder("WARN1", "WARN2"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder3 = builder2
-                .addWarningChecks()
-                .addWarningChecks(null);
+        CompileTestBuilder.CompilationTestBuilder builder3 = builder2
+                .expectedWarningMessages()
+                .expectedWarningMessages(null);
 
         MatcherAssert.assertThat(builder3
                 .createCompileTestConfiguration()
@@ -114,23 +116,23 @@ public class CompileTestBuilderTest {
 
     public void test_addMandatoryWarningChecks() {
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
-                .addMandatoryWarningChecks("MWARN1");
+                .expectedMandatoryWarningMessages("MWARN1");
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration()
                 .getMandatoryWarningMessageCheck(), Matchers.containsInAnyOrder("MWARN1"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder2 = builder
-                .addMandatoryWarningChecks("MWARN2");
+        CompileTestBuilder.CompilationTestBuilder builder2 = builder
+                .expectedMandatoryWarningMessages("MWARN2");
 
         MatcherAssert.assertThat(builder2
                 .createCompileTestConfiguration()
                 .getMandatoryWarningMessageCheck(), Matchers.containsInAnyOrder("MWARN1", "MWARN2"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder3 = builder2
-                .addMandatoryWarningChecks()
-                .addMandatoryWarningChecks(null);
+        CompileTestBuilder.CompilationTestBuilder builder3 = builder2
+                .expectedMandatoryWarningMessages()
+                .expectedMandatoryWarningMessages(null);
 
         MatcherAssert.assertThat(builder3
                 .createCompileTestConfiguration()
@@ -141,23 +143,23 @@ public class CompileTestBuilderTest {
 
     public void test_addNoteChecks() {
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
-                .addNoteChecks("NOTE1");
+                .expectedNoteMessages("NOTE1");
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration()
                 .getNoteMessageCheck(), Matchers.containsInAnyOrder("NOTE1"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder2 = builder
-                .addNoteChecks("NOTE2");
+        CompileTestBuilder.CompilationTestBuilder builder2 = builder
+                .expectedNoteMessages("NOTE2");
 
         MatcherAssert.assertThat(builder2
                 .createCompileTestConfiguration()
                 .getNoteMessageCheck(), Matchers.containsInAnyOrder("NOTE1", "NOTE2"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder3 = builder2
-                .addNoteChecks()
-                .addNoteChecks(null);
+        CompileTestBuilder.CompilationTestBuilder builder3 = builder2
+                .expectedNoteMessages()
+                .expectedNoteMessages(null);
 
         MatcherAssert.assertThat(builder3
                 .createCompileTestConfiguration()
@@ -168,23 +170,23 @@ public class CompileTestBuilderTest {
 
     public void test_addErrorChecks() {
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
-                .addErrorChecks("ERROR1");
+                .expectedErrorMessages("ERROR1");
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration()
                 .getErrorMessageCheck(), Matchers.containsInAnyOrder("ERROR1"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder2 = builder
-                .addErrorChecks("ERROR2");
+        CompileTestBuilder.CompilationTestBuilder builder2 = builder
+                .expectedErrorMessages("ERROR2");
 
         MatcherAssert.assertThat(builder2
                 .createCompileTestConfiguration()
                 .getErrorMessageCheck(), Matchers.containsInAnyOrder("ERROR1", "ERROR2"));
 
-        CompileTestBuilder.CompileTimeTestBuilder builder3 = builder2
-                .addErrorChecks()
-                .addErrorChecks(null);
+        CompileTestBuilder.CompilationTestBuilder builder3 = builder2
+                .expectedErrorMessages()
+                .expectedErrorMessages(null);
 
         MatcherAssert.assertThat(builder3
                 .createCompileTestConfiguration()
@@ -196,7 +198,7 @@ public class CompileTestBuilderTest {
     @Test
     public void test_compilationShouldSucceeed() {
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest();
 
         MatcherAssert.assertThat(builder.compilationShouldSucceed().createCompileTestConfiguration().getCompilationShouldSucceed(), Matchers.is(Boolean.TRUE));
@@ -211,7 +213,7 @@ public class CompileTestBuilderTest {
         JavaFileObject testSource1 = Mockito.mock(JavaFileObject.class);
         JavaFileObject testSource2 = Mockito.mock(JavaFileObject.class);
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
                 .addSources(testSource1)
                 .addSources(testSource2);
@@ -221,19 +223,6 @@ public class CompileTestBuilderTest {
 
     }
 
-    private static class SimpleTestProcessor1 extends AbstractProcessor {
-        @Override
-        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-            return false;
-        }
-    }
-
-    private static class SimpleTestProcessor2 extends AbstractProcessor {
-        @Override
-        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-            return false;
-        }
-    }
 
     @Test
     public void test_useProcessors() {
@@ -241,11 +230,11 @@ public class CompileTestBuilderTest {
         Class<? extends Processor> testProcessor1 = SimpleTestProcessor1.class;
         Class<? extends Processor> testProcessor2 = SimpleTestProcessor2.class;
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
-                .useProcessors(testProcessor1)
-                .useProcessors(testProcessor2)
-                .useProcessors((Class<? extends Processor>) null);
+                .addProcessors(testProcessor1)
+                .addProcessors(testProcessor2)
+                .addProcessors((Class<? extends Processor>) null);
 
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration().getProcessorTypes(), Matchers.containsInAnyOrder(testProcessor1, testProcessor2));
@@ -259,10 +248,10 @@ public class CompileTestBuilderTest {
         Class<? extends Processor> testProcessor1 = SimpleTestProcessor1.class;
         Class<? extends Processor> testProcessor2 = SimpleTestProcessor2.class;
 
-        CompileTestBuilder.CompileTimeTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.CompilationTestBuilder builder = CompileTestBuilder
                 .compilationTest()
-                .useProcessorAndExpectException(testProcessor1, IllegalArgumentException.class)
-                .useProcessorAndExpectException(testProcessor2, IllegalStateException.class);
+                .addProcessorWithExpectedException(testProcessor1, IllegalArgumentException.class)
+                .addProcessorWithExpectedException(testProcessor2, IllegalStateException.class);
 
 
         MatcherAssert.assertThat(builder.createCompileTestConfiguration().getProcessorsWithExpectedExceptions(), Matchers.<CompileTestConfiguration.ProcessorWithExpectedException>hasSize(2));
@@ -275,7 +264,7 @@ public class CompileTestBuilderTest {
 
         JavaFileObject javaFileObject = Mockito.mock(JavaFileObject.class);
 
-        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder
                 .unitTest()
                 .useSource(javaFileObject);
 
@@ -289,7 +278,7 @@ public class CompileTestBuilderTest {
         JavaFileObject javaFileObject1 = Mockito.mock(JavaFileObject.class);
         JavaFileObject javaFileObject2 = Mockito.mock(JavaFileObject.class);
 
-        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder
                 .unitTest()
                 .useSource(javaFileObject1)
                 .useSource(javaFileObject2);
@@ -302,7 +291,7 @@ public class CompileTestBuilderTest {
     public void test_useSource_addNullValuedSource() {
 
 
-        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder
                 .unitTest()
                 .useSource(null);
 
@@ -313,7 +302,7 @@ public class CompileTestBuilderTest {
     public void test_useProcessor_addNullValuedProcessor() {
 
 
-        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder
                 .unitTest()
                 .useProcessor((Processor) null);
 
@@ -324,7 +313,7 @@ public class CompileTestBuilderTest {
     public void test_useProcessor_addNullValuedUnitTestProcessor() {
 
 
-        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder.UnitTestBuilder builder = CompileTestBuilder
                 .unitTest()
                 .useProcessor((UnitTestProcessor) null);
 
@@ -334,9 +323,9 @@ public class CompileTestBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_CompileTimeTestBuilder_useProcessorAndExpectException_addNullValuedProcessor() {
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .compilationTest()
-                .useProcessorAndExpectException(null, IllegalStateException.class);
+                .addProcessorWithExpectedException(null, IllegalStateException.class);
 
 
     }
@@ -351,9 +340,9 @@ public class CompileTestBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_CompileTimeTestBuilder_useProcessorAndExpectException_addNullValuedException() {
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .compilationTest()
-                .useProcessorAndExpectException(SimpleTestProcessor.class, null);
+                .addProcessorWithExpectedException(SimpleTestProcessor.class, null);
 
 
     }

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/JavaFileObjectUtilsTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/JavaFileObjectUtilsTest.java
@@ -25,7 +25,7 @@ public class JavaFileObjectUtilsTest {
 
         final String content = "test";
 
-        JavaFileObject fileObject = JavaFileObjectUtils.readFromString("abc", content);
+        JavaFileObject fileObject = JavaFileObjectUtils.readFromString( content);
 
         MatcherAssert.assertThat((String) fileObject.getCharContent(false), Matchers.is(content));
 
@@ -36,7 +36,7 @@ public class JavaFileObjectUtilsTest {
 
         final String content = "test";
 
-        JavaFileObject fileObject = JavaFileObjectUtils.readFromString("abc", content);
+        JavaFileObject fileObject = JavaFileObjectUtils.readFromString( content);
 
         BufferedReader bufferedReader = new BufferedReader(fileObject.openReader(false));
 
@@ -48,7 +48,7 @@ public class JavaFileObjectUtilsTest {
 
         final String content = "test";
 
-        JavaFileObject fileObject = JavaFileObjectUtils.readFromString("abc", content);
+        JavaFileObject fileObject = JavaFileObjectUtils.readFromString( content);
 
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(fileObject.openInputStream()));
 

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/TestUtilities.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/TestUtilities.java
@@ -1,0 +1,33 @@
+package io.toolisticon.compiletesting;
+
+import org.hamcrest.MatcherAssert;
+
+public final class TestUtilities {
+
+    private TestUtilities() {
+
+    }
+
+    public static void assertAssertionMessageContainsMessageTokensAssertion(AssertionError assertionError, String message) {
+
+        MatcherAssert.assertThat("AssertionError message '" + assertionError.getMessage() + "' should have matched message string: '" + message + "'", assertAssertionMessageContainsMessageTokens(assertionError, message));
+
+    }
+
+    public static boolean assertAssertionMessageContainsMessageTokens(AssertionError assertionError, String message) {
+
+        String[] messageTokens = message.split("[%]s");
+
+        for (String messageToken : messageTokens) {
+
+            if (!assertionError.getMessage().contains(messageToken)) {
+                return false;
+            }
+
+        }
+
+        return true;
+
+    }
+
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestAnnotation1.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestAnnotation1.java
@@ -1,0 +1,12 @@
+package io.toolisticon.compiletesting.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SimpleTestAnnotation1 {
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestAnnotation2.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestAnnotation2.java
@@ -1,0 +1,12 @@
+package io.toolisticon.compiletesting.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SimpleTestAnnotation2 {
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestAnnotation3.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestAnnotation3.java
@@ -1,0 +1,13 @@
+package io.toolisticon.compiletesting.common;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SimpleTestAnnotation3 {
+}
+

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestProcessor1.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestProcessor1.java
@@ -1,0 +1,23 @@
+package io.toolisticon.compiletesting.common;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class SimpleTestProcessor1 extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+
+        return new HashSet<String>(Arrays.asList(SimpleTestAnnotation1.class.getCanonicalName()));
+
+    }
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestProcessor2.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestProcessor2.java
@@ -1,0 +1,22 @@
+package io.toolisticon.compiletesting.common;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SimpleTestProcessor2 extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+
+        return new HashSet<String>(Arrays.asList(SimpleTestAnnotation2.class.getCanonicalName()));
+
+    }
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestProcessor3.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/common/SimpleTestProcessor3.java
@@ -1,0 +1,22 @@
+package io.toolisticon.compiletesting.common;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SimpleTestProcessor3 extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+
+        return new HashSet<String>(Arrays.asList(SimpleTestAnnotation3.class.getCanonicalName()));
+
+    }
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/AnnotationProcessorWrapperTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/AnnotationProcessorWrapperTest.java
@@ -235,7 +235,7 @@ public class AnnotationProcessorWrapperTest {
     public void process_withoutExpectedExceptionShouldSucceed() {
 
 
-        CompileTestBuilder.createCompileTestBuilder().unitTest().useProcessor(
+        CompileTestBuilder.unitTest().useProcessor(
                 new UnitTestAnnotationProcessorClass(new UnitTestProcessor() {
                     @Override
                     public void unitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
@@ -253,7 +253,7 @@ public class AnnotationProcessorWrapperTest {
     public void process_testExpectedExceptionIsThrown_assertionShouldSucceed() {
 
 
-        CompileTestBuilder.createCompileTestBuilder().unitTest().useProcessor(
+        CompileTestBuilder.unitTest().useProcessor(
                 new UnitTestAnnotationProcessorClass(new UnitTestProcessor() {
                     @Override
                     public void unitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
@@ -270,7 +270,7 @@ public class AnnotationProcessorWrapperTest {
     public void process_testExpectedExceptionNotThrown_assertionShouldFail() {
 
         try {
-            CompileTestBuilder.createCompileTestBuilder().unitTest().useProcessor(
+            CompileTestBuilder.unitTest().useProcessor(
                     new UnitTestAnnotationProcessorClass(new UnitTestProcessor() {
                         @Override
                         public void unitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
@@ -289,7 +289,7 @@ public class AnnotationProcessorWrapperTest {
     public void process_testUnexpectedExceptionWasThrown_assertionShouldFail() {
 
         try {
-            CompileTestBuilder.createCompileTestBuilder().unitTest().useProcessor(
+            CompileTestBuilder.unitTest().useProcessor(
                     new UnitTestAnnotationProcessorClass(new UnitTestProcessor() {
                         @Override
                         public void unitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
@@ -308,7 +308,7 @@ public class AnnotationProcessorWrapperTest {
     public void process_testUnexpectedExceptionWasThrownWhenExpectedExceptionNotSet_assertionShouldFail() {
 
         try {
-            CompileTestBuilder.createCompileTestBuilder().unitTest().useProcessor(
+            CompileTestBuilder.unitTest().useProcessor(
                     new UnitTestAnnotationProcessorClass(new UnitTestProcessor() {
                         @Override
                         public void unitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestConfigurationTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestConfigurationTest.java
@@ -1,0 +1,699 @@
+package io.toolisticon.compiletesting.impl;
+
+import io.toolisticon.compiletesting.GeneratedFileObjectMatcher;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor1;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor2;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor3;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.processing.Processor;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import java.util.Set;
+
+/**
+ * Unit test for {@link CompileTestConfiguration}
+ */
+public class CompileTestConfigurationTest {
+
+    private CompileTestConfiguration unit;
+
+    // source files
+    private final JavaFileObject sourceJavaFileObject1 = Mockito.mock(JavaFileObject.class);
+    private final JavaFileObject sourceJavaFileObject2 = Mockito.mock(JavaFileObject.class);
+    private final JavaFileObject sourceJavaFileObject3 = Mockito.mock(JavaFileObject.class);
+
+    // processors
+    private final Processor processor1 = Mockito.mock(Processor.class);
+    private final Processor processor2 = Mockito.mock(Processor.class);
+    private final Processor processor3 = Mockito.mock(Processor.class);
+
+    // processorsWithExpectedExceptions
+    private final CompileTestConfiguration.ProcessorWithExpectedException processorWithExpectedException1 = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+    private final CompileTestConfiguration.ProcessorWithExpectedException processorWithExpectedException2 = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor2.class, IllegalArgumentException.class);
+    private final CompileTestConfiguration.ProcessorWithExpectedException processorWithExpectedException3 = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor3.class, IllegalThreadStateException.class);
+
+    // expectedThrownException
+    private final Class<? extends Throwable> expectedThrownException = IllegalStateException.class;
+
+    // compilationShouldSucceed
+    private final boolean compilationShouldSucceed = true;
+
+    // message checks
+    private final String message1 = "MESSAGE1";
+    private final String message2 = "MESSAGE2";
+    private final String message3 = "MESSAGE3";
+
+    // generatedJavaFileObjectChecks
+    private final CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectChecks1 = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(StandardLocation.SOURCE_OUTPUT,
+            "className1", JavaFileObject.Kind.SOURCE, Mockito.mock(JavaFileObject.class));
+    private final CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectChecks2 = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(StandardLocation.CLASS_OUTPUT,
+            "className2", JavaFileObject.Kind.CLASS, Mockito.mock(JavaFileObject.class));
+    private final CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectChecks3 = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(StandardLocation.SOURCE_OUTPUT,
+            "className3", JavaFileObject.Kind.SOURCE, Mockito.mock(GeneratedFileObjectMatcher.class));
+    private final CompileTestConfiguration.GeneratedJavaFileObjectCheck generatedJavaFileObjectChecks4 = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(StandardLocation.CLASS_OUTPUT,
+            "className4", JavaFileObject.Kind.CLASS, Mockito.mock(GeneratedFileObjectMatcher.class));
+
+    // generatedFileObjectChecks
+    private final CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectChecks1 = new CompileTestConfiguration.GeneratedFileObjectCheck(StandardLocation.SOURCE_OUTPUT,
+            "package1", "relativeName1", Mockito.mock(JavaFileObject.class));
+    private final CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectChecks2 = new CompileTestConfiguration.GeneratedFileObjectCheck(StandardLocation.CLASS_OUTPUT,
+            "package2", "relativeName1", Mockito.mock(JavaFileObject.class));
+    private final CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectChecks3 = new CompileTestConfiguration.GeneratedFileObjectCheck(StandardLocation.SOURCE_OUTPUT,
+            "package3", "relativeName3", Mockito.mock(GeneratedFileObjectMatcher.class));
+    private final CompileTestConfiguration.GeneratedFileObjectCheck generatedFileObjectChecks4 = new CompileTestConfiguration.GeneratedFileObjectCheck(StandardLocation.CLASS_OUTPUT,
+            "package4", "relativeName4", Mockito.mock(GeneratedFileObjectMatcher.class));
+
+
+    @Before
+    public void init() {
+        unit = new CompileTestConfiguration();
+    }
+
+    @Test
+    public void sourceFiles_addAndGet() {
+
+        unit.addSourceFiles(sourceJavaFileObject1, sourceJavaFileObject2, sourceJavaFileObject3);
+
+        // do assertion
+        assertSourceFiles(unit);
+
+    }
+
+    private void assertSourceFiles(CompileTestConfiguration configuration) {
+        MatcherAssert.assertThat(configuration.getSourceFiles(), Matchers.containsInAnyOrder(sourceJavaFileObject1, sourceJavaFileObject2, sourceJavaFileObject3));
+    }
+
+
+    @Test
+    public void processors_addAndGet() {
+
+        unit.addProcessors(processor1, processor2, processor3);
+
+        // do assertion
+        assertProcessors(unit);
+
+    }
+
+    private void assertProcessors(CompileTestConfiguration configuration) {
+        MatcherAssert.assertThat(configuration.getProcessors(), Matchers.containsInAnyOrder(processor1, processor2, processor3));
+    }
+
+    @Test
+    public void processorTypes_addAndGet() {
+
+        unit.addProcessorTypes(SimpleTestProcessor1.class, SimpleTestProcessor2.class, SimpleTestProcessor3.class);
+
+        // do assertion
+        assertProcessorTypes(unit);
+
+    }
+
+    private void assertProcessorTypes(CompileTestConfiguration configuration) {
+        MatcherAssert.assertThat(configuration.getProcessorTypes(), Matchers.containsInAnyOrder((Class<? extends Processor>) SimpleTestProcessor1.class, (Class<? extends Processor>) SimpleTestProcessor2.class, (Class<? extends Processor>) SimpleTestProcessor3.class));
+    }
+
+    @Test
+    public void processorsWithExpectedExceptions_addAndGet() {
+
+        unit.addProcessorWithExpectedException(processorWithExpectedException1.getProcessorType(), processorWithExpectedException1.getThrowable());
+        unit.addProcessorWithExpectedException(processorWithExpectedException2.getProcessorType(), processorWithExpectedException2.getThrowable());
+        unit.addProcessorWithExpectedException(processorWithExpectedException3.getProcessorType(), processorWithExpectedException3.getThrowable());
+
+        // do assertion
+        assertProcessorsWithExpectedExceptions(unit);
+
+    }
+
+    private void assertProcessorsWithExpectedExceptions(CompileTestConfiguration configuration) {
+        MatcherAssert.assertThat(configuration.getProcessorsWithExpectedExceptions(), Matchers.containsInAnyOrder(processorWithExpectedException1, processorWithExpectedException2, processorWithExpectedException3));
+    }
+
+    @Test
+    public void expectedThrownException_setAndGet() {
+
+        unit.setExpectedThrownException(expectedThrownException);
+
+        // do assertion
+        assertExpectedThrownException(unit, expectedThrownException);
+
+    }
+
+    @Test
+    public void expectedThrownException_overwriteValue() {
+
+        expectedThrownException_setAndGet();
+
+        unit.setExpectedThrownException(RuntimeException.class);
+
+        // do assertion
+        assertExpectedThrownException(unit, RuntimeException.class);
+
+    }
+
+    private void assertExpectedThrownException(CompileTestConfiguration configuration, Class<? extends Throwable> expectedThrownException) {
+        MatcherAssert.assertThat((Class) configuration.getExpectedThrownException(), Matchers.equalTo((Class) expectedThrownException));
+    }
+
+
+    @Test
+    public void compilationShouldSucceed_setAndGet() {
+
+        unit.setCompilationShouldSucceed(compilationShouldSucceed);
+
+        // do assertion
+        assertCompilationShouldSucceed(unit, compilationShouldSucceed);
+
+    }
+
+    @Test
+    public void compilationShouldSucceed_overwriteValue() {
+
+        expectedThrownException_setAndGet();
+
+        unit.setCompilationShouldSucceed(false);
+
+        // do assertion
+        assertCompilationShouldSucceed(unit, false);
+
+    }
+
+    private void assertCompilationShouldSucceed(CompileTestConfiguration configuration, Boolean compilationShouldSucceed) {
+        MatcherAssert.assertThat(configuration.getCompilationShouldSucceed(), Matchers.equalTo(compilationShouldSucceed));
+    }
+
+
+    @Test
+    public void noteMessageCheck_setAndGet() {
+
+        unit.addNoteMessageCheck(message1, message2);
+        unit.addNoteMessageCheck(message3);
+
+        // do assertion
+        assertMessages(unit.getNoteMessageCheck());
+
+    }
+
+    @Test
+    public void warningMessageCheck_setAndGet() {
+
+        unit.addWarningMessageCheck(message1, message2);
+        unit.addWarningMessageCheck(message3);
+
+        // do assertion
+        assertMessages(unit.getWarningMessageCheck());
+
+    }
+
+
+    @Test
+    public void mandatoryWarningMessageCheck_setAndGet() {
+
+        unit.addMandatoryWarningMessageCheck(message1, message2);
+        unit.addMandatoryWarningMessageCheck(message3);
+
+        // do assertion
+        assertMessages(unit.getMandatoryWarningMessageCheck());
+
+    }
+
+    @Test
+    public void errorMessageCheck_setAndGet() {
+
+        unit.addErrorMessageCheck(message1, message2);
+        unit.addErrorMessageCheck(message3);
+
+        // do assertion
+        assertMessages(unit.getErrorMessageCheck());
+
+    }
+
+
+    private void assertMessages(Set<String> messageSet) {
+        MatcherAssert.assertThat(messageSet, Matchers.containsInAnyOrder(message1, message2, message3));
+    }
+
+
+    @Test
+    public void generatedJavaFileObjectChecks_addAndGet() {
+
+        unit.addGeneratedJavaFileObjectCheck(generatedJavaFileObjectChecks1.getLocation(), generatedJavaFileObjectChecks1.getClassName(), generatedJavaFileObjectChecks1.getKind(), generatedJavaFileObjectChecks1.getExpectedJavaFileObject());
+        unit.addGeneratedJavaFileObjectCheck(generatedJavaFileObjectChecks2.getLocation(), generatedJavaFileObjectChecks2.getClassName(), generatedJavaFileObjectChecks2.getKind(), generatedJavaFileObjectChecks2.getExpectedJavaFileObject());
+
+        unit.addGeneratedJavaFileObjectCheck(generatedJavaFileObjectChecks3.getLocation(), generatedJavaFileObjectChecks3.getClassName(), generatedJavaFileObjectChecks3.getKind(), generatedJavaFileObjectChecks3.getGeneratedFileObjectMatcher());
+        unit.addGeneratedJavaFileObjectCheck(generatedJavaFileObjectChecks4.getLocation(), generatedJavaFileObjectChecks4.getClassName(), generatedJavaFileObjectChecks4.getKind(), generatedJavaFileObjectChecks4.getGeneratedFileObjectMatcher());
+
+
+        // do assertion
+        assertGeneratedJavaFileObjectChecks(unit);
+    }
+
+    private void assertGeneratedJavaFileObjectChecks(CompileTestConfiguration configuration) {
+        MatcherAssert.assertThat(configuration.getGeneratedJavaFileObjectChecks(), Matchers.containsInAnyOrder(generatedJavaFileObjectChecks1, generatedJavaFileObjectChecks2, generatedJavaFileObjectChecks3, generatedJavaFileObjectChecks4));
+    }
+
+
+    @Test
+    public void generatedFileObjectChecks_addAndGet() {
+
+        unit.addGeneratedFileObjectCheck(generatedFileObjectChecks1.getLocation(), generatedFileObjectChecks1.getPackageName(), generatedFileObjectChecks1.getRelativeName(), generatedFileObjectChecks1.getExpectedFileObject());
+        unit.addGeneratedFileObjectCheck(generatedFileObjectChecks2.getLocation(), generatedFileObjectChecks2.getPackageName(), generatedFileObjectChecks2.getRelativeName(), generatedFileObjectChecks2.getExpectedFileObject());
+
+        unit.addGeneratedFileObjectCheck(generatedFileObjectChecks3.getLocation(), generatedFileObjectChecks3.getPackageName(), generatedFileObjectChecks3.getRelativeName(), generatedFileObjectChecks3.getGeneratedFileObjectMatcher());
+        unit.addGeneratedFileObjectCheck(generatedFileObjectChecks4.getLocation(), generatedFileObjectChecks4.getPackageName(), generatedFileObjectChecks4.getRelativeName(), generatedFileObjectChecks4.getGeneratedFileObjectMatcher());
+
+
+        // do assertion
+        assertGeneratedFileObjectChecks(unit);
+    }
+
+    private void assertGeneratedFileObjectChecks(CompileTestConfiguration configuration) {
+        MatcherAssert.assertThat(configuration.getGeneratedFileObjectChecks(), Matchers.containsInAnyOrder(generatedFileObjectChecks1, generatedFileObjectChecks2, generatedFileObjectChecks3, generatedFileObjectChecks4));
+    }
+
+    @Test
+    public void cloneConfiguration_cloneConfiguration() {
+
+        sourceFiles_addAndGet();
+        processors_addAndGet();
+        processorTypes_addAndGet();
+        processorsWithExpectedExceptions_addAndGet();
+        expectedThrownException_setAndGet();
+        noteMessageCheck_setAndGet();
+        warningMessageCheck_setAndGet();
+        mandatoryWarningMessageCheck_setAndGet();
+        errorMessageCheck_setAndGet();
+        generatedJavaFileObjectChecks_addAndGet();
+        generatedFileObjectChecks_addAndGet();
+
+        CompileTestConfiguration clonedConfiguration = CompileTestConfiguration.cloneConfiguration(unit);
+
+        assertSourceFiles(clonedConfiguration);
+        assertProcessors(clonedConfiguration);
+        assertProcessorTypes(clonedConfiguration);
+        assertProcessorsWithExpectedExceptions(clonedConfiguration);
+        assertExpectedThrownException(clonedConfiguration, expectedThrownException);
+        assertMessages(clonedConfiguration.getNoteMessageCheck());
+        assertMessages(clonedConfiguration.getWarningMessageCheck());
+        assertMessages(clonedConfiguration.getMandatoryWarningMessageCheck());
+        assertMessages(clonedConfiguration.getErrorMessageCheck());
+        assertGeneratedJavaFileObjectChecks(clonedConfiguration);
+        assertGeneratedFileObjectChecks(clonedConfiguration);
+
+    }
+
+
+    @Test
+    public void wrappedProcessorCacheIsResetCorrectly_addProcessors() {
+
+        processorTypes_addAndGet();
+
+        Set<AnnotationProcessorWrapper> previousCache = unit.getWrappedProcessors();
+
+        processors_addAndGet();
+
+        Set<AnnotationProcessorWrapper> currentCache = unit.getWrappedProcessors();
+        MatcherAssert.assertThat("Cache instances must not match!!!", currentCache != previousCache);
+
+
+    }
+
+    @Test
+    public void wrappedProcessorCacheIsResetCorrectly_addProcessorsTypes() {
+        processors_addAndGet();
+
+        Set<AnnotationProcessorWrapper> previousCache = unit.getWrappedProcessors();
+
+        processorTypes_addAndGet();
+
+        Set<AnnotationProcessorWrapper> currentCache = unit.getWrappedProcessors();
+        MatcherAssert.assertThat("Cache instances must not match!!!", currentCache != previousCache);
+
+    }
+
+    @Test
+    public void wrappedProcessorCacheIsResetCorrectly_addProcessorsTypesWithExpectedExceptions() {
+        processors_addAndGet();
+
+        Set<AnnotationProcessorWrapper> previousCache = unit.getWrappedProcessors();
+
+        processorsWithExpectedExceptions_addAndGet();
+
+        Set<AnnotationProcessorWrapper> currentCache = unit.getWrappedProcessors();
+        MatcherAssert.assertThat("Cache instances must not match!!!", currentCache != previousCache);
+
+    }
+
+    @Test
+    public void wrappedProcessorCacheSubsequentCallsShouldReturnSameCache() {
+        processors_addAndGet();
+
+        Set<AnnotationProcessorWrapper> previousCache = unit.getWrappedProcessors();
+        Set<AnnotationProcessorWrapper> currentCache = unit.getWrappedProcessors();
+
+        MatcherAssert.assertThat("Subsequent calls to get wrapped processors should return same cache set!!!", currentCache == previousCache);
+
+    }
+
+
+    // -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    // -- STATIC INNER CLASSES TESTS
+    // -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+
+
+    // -------------------------------------------------------------------
+    // -- ProcessorWithExpectedException
+    // -------------------------------------------------------------------
+
+    @Test
+    public void processorWithExpectedException_matching() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+
+        MatcherAssert.assertThat("Objects should be detected as equal", unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should be detected as equal", otherObj.equals(unit));
+
+        MatcherAssert.assertThat("HashCodes should be identical", unit.hashCode() == otherObj.hashCode());
+
+    }
+
+    @Test
+    public void processorWithExpectedException_matching_processorIsNull() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(null, IllegalStateException.class);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(null, IllegalStateException.class);
+
+        MatcherAssert.assertThat("Objects should be detected as equal", unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should be detected as equal", otherObj.equals(unit));
+
+        MatcherAssert.assertThat("HashCodes should be identical", unit.hashCode() == otherObj.hashCode());
+
+    }
+
+    @Test
+    public void processorWithExpectedException_matching_throwableIsNull() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, null);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, null);
+
+        MatcherAssert.assertThat("Objects should be detected as equal", unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should be detected as equal", otherObj.equals(unit));
+
+        MatcherAssert.assertThat("HashCodes should be identical", unit.hashCode() == otherObj.hashCode());
+
+    }
+
+    @Test
+    public void processorWithExpectedException_matching_allParametersAreNull() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(null, null);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(null, null);
+
+        MatcherAssert.assertThat("Objects should be detected as equal", unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should be detected as equal", otherObj.equals(unit));
+
+        MatcherAssert.assertThat("HashCodes should be identical", unit.hashCode() == otherObj.hashCode());
+
+    }
+
+    @Test
+    public void processorWithExpectedException_nonMatching_passedObjectIsNull() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+
+        MatcherAssert.assertThat("Objects should be detected as not equal", !unit.equals(null));
+
+
+    }
+
+    @Test
+    public void processorWithExpectedException_nonMatching_oneProcessorIsNull() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(null, IllegalStateException.class);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+
+    }
+
+    @Test
+    public void processorWithExpectedException_nonMatching_oneThrowableIsNull() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, null);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+
+    }
+
+    @Test
+    public void processorWithExpectedException_nonMatching_processorIsDifferent() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor2.class, IllegalStateException.class);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+
+    }
+
+    @Test
+    public void processorWithExpectedException_nonMatching_throwableIsDifferent() {
+
+        CompileTestConfiguration.ProcessorWithExpectedException unit = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalStateException.class);
+        CompileTestConfiguration.ProcessorWithExpectedException otherObj = new CompileTestConfiguration.ProcessorWithExpectedException(SimpleTestProcessor1.class, IllegalArgumentException.class);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+
+    }
+
+
+    // -------------------------------------------------------------------
+    // -- GeneratedFileObjectCheck
+    // -------------------------------------------------------------------
+
+
+    @Test
+    public void generatedFileObjectCheck_matching_withFileObject() {
+
+        CompileTestConfiguration.GeneratedFileObjectCheck otherObj = new CompileTestConfiguration.GeneratedFileObjectCheck(generatedFileObjectChecks1.getLocation(),
+                generatedFileObjectChecks1.getPackageName(), generatedFileObjectChecks1.getRelativeName(), generatedFileObjectChecks1.getExpectedFileObject());
+
+        MatcherAssert.assertThat("Objects should be detected as equal", generatedFileObjectChecks1.equals(otherObj));
+        MatcherAssert.assertThat("Objects should be detected as equal", otherObj.equals(generatedFileObjectChecks1));
+
+        MatcherAssert.assertThat("HashCodes should be identical", generatedFileObjectChecks1.hashCode() == otherObj.hashCode());
+
+    }
+
+    @Test
+    public void generatedFileObjectCheck_notMatching() {
+
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedFileObjectChecks1.equals(generatedFileObjectChecks2));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedFileObjectChecks1.equals(generatedFileObjectChecks3));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedFileObjectChecks1.equals(generatedFileObjectChecks4));
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedFileObjectChecks2.equals(generatedFileObjectChecks1));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedFileObjectChecks3.equals(generatedFileObjectChecks1));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedFileObjectChecks4.equals(generatedFileObjectChecks1));
+
+    }
+
+    @Test
+    public void generatedFileObjectCheck_notMatchingSingleField_withFileObject() {
+
+        // location differs
+        JavaFileManager.Location alternativeLocation = StandardLocation.SOURCE_PATH;
+        MatcherAssert.assertThat("PRECONDITION locations must not match", alternativeLocation != generatedFileObjectChecks1.getLocation());
+        generatedFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedFileObjectChecks1, alternativeLocation,
+                generatedFileObjectChecks1.getPackageName(), generatedFileObjectChecks1.getRelativeName(), generatedFileObjectChecks1.getExpectedFileObject());
+
+        // packageName differs
+        String alternativePackageName = "XXX";
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativePackageName.equals(generatedFileObjectChecks1.getPackageName()));
+        generatedFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedFileObjectChecks1, generatedFileObjectChecks1.getLocation(),
+                alternativePackageName, generatedFileObjectChecks1.getRelativeName(), generatedFileObjectChecks1.getExpectedFileObject());
+
+        // relativeName differs
+        String alternativeRelativeName = "XXX";
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativeRelativeName.equals(generatedFileObjectChecks1.getRelativeName()));
+        generatedFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedFileObjectChecks1, generatedFileObjectChecks1.getLocation(),
+                generatedFileObjectChecks1.getPackageName(), alternativeRelativeName, generatedFileObjectChecks1.getExpectedFileObject());
+
+        // expectedFileObject differs
+        generatedFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedFileObjectChecks1, generatedFileObjectChecks1.getLocation(),
+                generatedFileObjectChecks1.getPackageName(), generatedFileObjectChecks1.getRelativeName(), Mockito.mock(FileObject.class));
+
+    }
+
+    private void generatedFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(CompileTestConfiguration.GeneratedFileObjectCheck unit, JavaFileManager.Location location, String packageName, String relativeName, FileObject expectedFileObject) {
+
+        CompileTestConfiguration.GeneratedFileObjectCheck otherObj = new CompileTestConfiguration.GeneratedFileObjectCheck(location,
+                packageName, packageName, expectedFileObject);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+    }
+
+    @Test
+    public void generatedFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher() {
+
+        // location differs
+        JavaFileManager.Location alternativeLocation = StandardLocation.SOURCE_PATH;
+        MatcherAssert.assertThat("PRECONDITION locations must not match", alternativeLocation != generatedFileObjectChecks3.getLocation());
+        generatedFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedFileObjectChecks3, alternativeLocation,
+                generatedFileObjectChecks3.getPackageName(), generatedFileObjectChecks3.getRelativeName(), generatedFileObjectChecks3.getGeneratedFileObjectMatcher());
+
+        // packageName differs
+        String alternativePackageName = "XXX";
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativePackageName.equals(generatedFileObjectChecks3.getPackageName()));
+        generatedFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedFileObjectChecks3, generatedFileObjectChecks3.getLocation(),
+                alternativePackageName, generatedFileObjectChecks3.getRelativeName(), generatedFileObjectChecks3.getGeneratedFileObjectMatcher());
+
+        // relativeName differs
+        String alternativeRelativeName = "XXX";
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativeRelativeName.equals(generatedFileObjectChecks3.getRelativeName()));
+        generatedFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedFileObjectChecks3, generatedFileObjectChecks3.getLocation(),
+                generatedFileObjectChecks3.getPackageName(), alternativeRelativeName, generatedFileObjectChecks3.getGeneratedFileObjectMatcher());
+
+        // expectedFileObject differs
+        generatedFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedFileObjectChecks3, generatedFileObjectChecks3.getLocation(),
+                generatedFileObjectChecks3.getPackageName(), generatedFileObjectChecks3.getRelativeName(), Mockito.mock(GeneratedFileObjectMatcher.class));
+
+    }
+
+    private void generatedFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(CompileTestConfiguration.GeneratedFileObjectCheck unit, JavaFileManager.Location location, String packageName, String relativeName, GeneratedFileObjectMatcher<FileObject> generatedFileObjectMatcher) {
+
+        CompileTestConfiguration.GeneratedFileObjectCheck otherObj = new CompileTestConfiguration.GeneratedFileObjectCheck(location,
+                packageName, packageName, generatedFileObjectMatcher);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+    }
+
+    // -------------------------------------------------------------------
+    // -- GeneratedJavaFileObjectCheck
+    // -------------------------------------------------------------------
+
+    @Test
+    public void generatedJavaFileObjectCheck_matching_withFileObject() {
+
+        CompileTestConfiguration.GeneratedJavaFileObjectCheck otherObj = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(generatedJavaFileObjectChecks1.getLocation(),
+                generatedJavaFileObjectChecks1.getClassName(), generatedJavaFileObjectChecks1.getKind(), generatedJavaFileObjectChecks1.getExpectedJavaFileObject());
+
+        MatcherAssert.assertThat("Objects should be detected as equal", generatedJavaFileObjectChecks1.equals(otherObj));
+        MatcherAssert.assertThat("Objects should be detected as equal", otherObj.equals(generatedJavaFileObjectChecks1));
+
+        MatcherAssert.assertThat("HashCodes should be identical", generatedJavaFileObjectChecks1.hashCode() == otherObj.hashCode());
+
+    }
+
+    @Test
+    public void generatedJavaFileObjectCheck_notMatching() {
+
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedJavaFileObjectChecks1.equals(generatedJavaFileObjectChecks2));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedJavaFileObjectChecks1.equals(generatedJavaFileObjectChecks3));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedJavaFileObjectChecks1.equals(generatedJavaFileObjectChecks4));
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedJavaFileObjectChecks2.equals(generatedJavaFileObjectChecks1));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedJavaFileObjectChecks3.equals(generatedJavaFileObjectChecks1));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !generatedJavaFileObjectChecks4.equals(generatedJavaFileObjectChecks1));
+
+    }
+
+    @Test
+    public void generatedJavaFileObjectCheck_notMatchingSingleField_withFileObject() {
+
+        // location differs
+        JavaFileManager.Location alternativeLocation = StandardLocation.SOURCE_PATH;
+        MatcherAssert.assertThat("PRECONDITION locations must not match", alternativeLocation != generatedJavaFileObjectChecks1.getLocation());
+        generatedJavaFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedJavaFileObjectChecks1, alternativeLocation,
+                generatedJavaFileObjectChecks1.getClassName(), generatedJavaFileObjectChecks1.getKind(), generatedJavaFileObjectChecks1.getExpectedJavaFileObject());
+
+        // className differs
+        String alternativeClassName = "XXX";
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativeClassName.equals(generatedJavaFileObjectChecks1.getClassName()));
+        generatedJavaFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedJavaFileObjectChecks1, generatedFileObjectChecks1.getLocation(),
+                alternativeClassName, generatedJavaFileObjectChecks1.getKind(), generatedJavaFileObjectChecks1.getExpectedJavaFileObject());
+
+        // kind differs
+        JavaFileObject.Kind alternativeKind = JavaFileObject.Kind.OTHER;
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativeKind.equals(generatedJavaFileObjectChecks1.getKind()));
+        generatedJavaFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedJavaFileObjectChecks1, generatedJavaFileObjectChecks1.getLocation(),
+                generatedJavaFileObjectChecks1.getClassName(), alternativeKind, generatedJavaFileObjectChecks1.getExpectedJavaFileObject());
+
+        // expectedFileObject differs
+        generatedJavaFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(generatedJavaFileObjectChecks1, generatedJavaFileObjectChecks1.getLocation(),
+                generatedJavaFileObjectChecks1.getClassName(), generatedJavaFileObjectChecks1.getKind(), Mockito.mock(JavaFileObject.class));
+
+    }
+
+    private void generatedJavaFileObjectCheck_notMatchingSingleField_withFileObject_singleTest(CompileTestConfiguration.GeneratedJavaFileObjectCheck unit, JavaFileManager.Location location, String className, JavaFileObject.Kind kind, JavaFileObject expectedJavaFileObject) {
+
+        CompileTestConfiguration.GeneratedJavaFileObjectCheck otherObj = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(location,
+                className, kind, expectedJavaFileObject);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+    }
+
+    @Test
+    public void generatedJavaFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher() {
+
+        // location differs
+        JavaFileManager.Location alternativeLocation = StandardLocation.SOURCE_PATH;
+        MatcherAssert.assertThat("PRECONDITION locations must not match", alternativeLocation != generatedJavaFileObjectChecks3.getLocation());
+        generatedJavaFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedJavaFileObjectChecks3, alternativeLocation,
+                generatedJavaFileObjectChecks3.getClassName(), generatedJavaFileObjectChecks3.getKind(), Mockito.mock(GeneratedFileObjectMatcher.class));
+
+        // className differs
+        String alternativeClassName = "XXX";
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativeClassName.equals(generatedJavaFileObjectChecks3.getClassName()));
+        generatedJavaFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedJavaFileObjectChecks3, generatedJavaFileObjectChecks3.getLocation(),
+                alternativeClassName, generatedJavaFileObjectChecks3.getKind(), Mockito.mock(GeneratedFileObjectMatcher.class));
+
+        // kind differs
+        JavaFileObject.Kind alternativeKind = JavaFileObject.Kind.OTHER;
+        MatcherAssert.assertThat("PRECONDITION locations must not match", !alternativeKind.equals(generatedJavaFileObjectChecks3.getKind()));
+        generatedJavaFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedJavaFileObjectChecks3, generatedJavaFileObjectChecks3.getLocation(),
+                generatedJavaFileObjectChecks3.getClassName(), alternativeKind, Mockito.mock(GeneratedFileObjectMatcher.class));
+
+        // expectedFileObject differs
+        generatedJavaFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(generatedJavaFileObjectChecks3, generatedJavaFileObjectChecks3.getLocation(),
+                generatedJavaFileObjectChecks3.getClassName(), generatedJavaFileObjectChecks3.getKind(), Mockito.mock(GeneratedFileObjectMatcher.class));
+
+    }
+
+    private void generatedJavaFileObjectCheck_notMatchingSingleField_withGeneratedFileObjectMatcher_singleTest(CompileTestConfiguration.GeneratedJavaFileObjectCheck unit, JavaFileManager.Location location, String className, JavaFileObject.Kind kind, GeneratedFileObjectMatcher<JavaFileObject> generatedFileObjectMatcher) {
+
+        CompileTestConfiguration.GeneratedJavaFileObjectCheck otherObj = new CompileTestConfiguration.GeneratedJavaFileObjectCheck(location,
+                className, kind, generatedFileObjectMatcher);
+
+        MatcherAssert.assertThat("Objects should not be detected as equal", !unit.equals(otherObj));
+        MatcherAssert.assertThat("Objects should not be detected as equal", !otherObj.equals(unit));
+
+    }
+
+
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestFileManagerTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestFileManagerTest.java
@@ -63,7 +63,7 @@ public class CompileTestFileManagerTest {
     public void test_InMemoryOutputJavaFileObject_setContent_nullValued() throws IOException, URISyntaxException {
 
         CompileTestFileManager compileTestFileManager = new CompileTestFileManager(standardJavaFileManager);
-        CompileTestFileManager.InMemoryOutputJavaFileObject unit = compileTestFileManager.new InMemoryOutputJavaFileObject(new URI("string://abc"), JavaFileObject.Kind.OTHER);
+        CompileTestFileManager.InMemoryOutputJavaFileObject unit = new CompileTestFileManager.InMemoryOutputJavaFileObject(new URI("string://abc"), JavaFileObject.Kind.OTHER);
 
         unit.setContent(null);
 
@@ -75,7 +75,7 @@ public class CompileTestFileManagerTest {
     public void test_InMemoryOutputJavaFileObject_setContent() throws IOException, URISyntaxException {
 
         CompileTestFileManager compileTestFileManager = new CompileTestFileManager(standardJavaFileManager);
-        CompileTestFileManager.InMemoryOutputJavaFileObject unit = compileTestFileManager.new InMemoryOutputJavaFileObject(new URI("string://abc"), JavaFileObject.Kind.OTHER);
+        CompileTestFileManager.InMemoryOutputJavaFileObject unit = new CompileTestFileManager. InMemoryOutputJavaFileObject(new URI("string://abc"), JavaFileObject.Kind.OTHER);
 
         unit.setContent("ABC".getBytes());
 
@@ -87,7 +87,7 @@ public class CompileTestFileManagerTest {
     public void test_InMemoryOutputJavaFileObject_openReader() throws IOException, URISyntaxException {
 
         CompileTestFileManager compileTestFileManager = new CompileTestFileManager(standardJavaFileManager);
-        CompileTestFileManager.InMemoryOutputJavaFileObject unit = compileTestFileManager.new InMemoryOutputJavaFileObject(new URI("string://abc"), JavaFileObject.Kind.OTHER);
+        CompileTestFileManager.InMemoryOutputJavaFileObject unit = new CompileTestFileManager. InMemoryOutputJavaFileObject(new URI("string://abc"), JavaFileObject.Kind.OTHER);
 
         unit.setContent("ABC".getBytes());
 
@@ -106,8 +106,7 @@ public class CompileTestFileManagerTest {
     @Test
     public void test_FileObjectCache() throws URISyntaxException {
 
-        CompileTestFileManager compileTestFileManager = new CompileTestFileManager(standardJavaFileManager);
-        CompileTestFileManager.FileObjectCache unit = compileTestFileManager.new FileObjectCache();
+        CompileTestFileManager.FileObjectCache unit = new CompileTestFileManager.FileObjectCache();
 
         JavaFileObject javaFileObject = Mockito.mock(JavaFileObject.class);
 

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestTest.java
@@ -24,7 +24,7 @@ public class CompileTestTest {
 
 
         try {
-            CompileTestBuilder.createCompileTestBuilder()
+            CompileTestBuilder
                     .unitTest()
                     .useProcessor(new UnitTestProcessor() {
                         @Override
@@ -47,9 +47,9 @@ public class CompileTestTest {
 
                     .compilationShouldSucceed()
 
-                    .addGeneratedFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt")
-                    .addGeneratedFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt", JavaFileObjectUtils.readFromString("XXX", "TATA!"))
-                    .addGeneratedFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt", new GeneratedFileObjectMatcher<FileObject>() {
+                    .expectedFileObjectExists(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt")
+                    .expectedFileObjectExists(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt", JavaFileObjectUtils.readFromString("TATA!"))
+                    .expectedFileObjectExists(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt", new GeneratedFileObjectMatcher<FileObject>() {
                         @Override
                         public boolean check(FileObject fileObject) throws IOException {
                             return fileObject.getCharContent(false).toString().contains("TAT");
@@ -67,7 +67,7 @@ public class CompileTestTest {
 
 
         try {
-            CompileTestBuilder.createCompileTestBuilder()
+            CompileTestBuilder
                     .unitTest()
                     .useProcessor(new UnitTestProcessor() {
                         @Override
@@ -87,14 +87,15 @@ public class CompileTestTest {
                     })
 
                     .compilationShouldSucceed()
-                    .addGeneratedFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt", JavaFileObjectUtils.readFromString("test", "WURST!"))
+                    .expectedFileObjectExists(StandardLocation.SOURCE_OUTPUT, "root", "Jupp.txt", JavaFileObjectUtils.readFromString("WURST!"))
                     .testCompilation();
 
             Assert.fail("Should have triggered an assertion error");
 
         } catch (AssertionError e) {
 
-            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("exists but doesn't match expected FileObject"));
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("exists but doesn't match expected FileObject" +
+                    ""));
 
         }
 
@@ -103,7 +104,7 @@ public class CompileTestTest {
 
     @Test
     public void test_JavaFileObjectExists() {
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .unitTest()
                 .useProcessor(new UnitTestProcessor() {
                     @Override
@@ -125,10 +126,10 @@ public class CompileTestTest {
                 })
 
                 .compilationShouldSucceed()
-                .addGeneratedJavaFileObjectExistsCheck(StandardLocation.CLASS_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.CLASS)
-                .addGeneratedJavaFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.SOURCE)
-                .addGeneratedJavaFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.SOURCE, JavaFileObjectUtils.readFromString("xyz", "package io.toolisticon.compiletesting;\npublic class CheckTest{}"))
-                .addGeneratedJavaFileObjectExistsCheck(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.SOURCE, new GeneratedFileObjectMatcher<JavaFileObject>() {
+                .expectedJavaFileObjectExists(StandardLocation.CLASS_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.CLASS)
+                .expectedJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.SOURCE)
+                .expectedJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.SOURCE, JavaFileObjectUtils.readFromString("xyz", "package io.toolisticon.compiletesting;\npublic class CheckTest{}"))
+                .expectedJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.compiletesting.CheckTest", JavaFileObject.Kind.SOURCE, new GeneratedFileObjectMatcher<JavaFileObject>() {
                     @Override
                     public boolean check(JavaFileObject fileObject) throws IOException {
                         return fileObject.getCharContent(false).toString().contains("public class CheckTest{}");

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestUtilitiesTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/impl/CompileTestUtilitiesTest.java
@@ -1,0 +1,119 @@
+package io.toolisticon.compiletesting.impl;
+
+import io.toolisticon.compiletesting.common.SimpleTestProcessor1;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import java.util.Set;
+
+/**
+ * Unit test for {@link CompileTestUtilities}.
+ */
+public class CompileTestUtilitiesTest {
+
+    @Test
+    public void getAnnotationProcessorWasAppliedMessage_concreteProcessor() {
+        Processor processor = new SimpleTestProcessor1();
+        MatcherAssert.assertThat(
+                CompileTestUtilities.getAnnotationProcessorWasAppliedMessage(processor),
+                Matchers.equalTo(
+                        CompileTestUtilities.TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED
+                                .replaceFirst("[%]s", SimpleTestProcessor1.class.getCanonicalName()
+                                )
+                                .replaceFirst("[%]s", "" + System.identityHashCode(processor))));
+    }
+
+    @Test
+    public void getAnnotationProcessorWasAppliedMessage_anynomousProcessor_class() {
+
+        Processor processor = new AbstractProcessor() {
+            @Override
+            public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                return false;
+            }
+        };
+
+        MatcherAssert.assertThat(
+                CompileTestUtilities.getAnnotationProcessorWasAppliedMessage(processor),
+                Matchers.equalTo(
+                        CompileTestUtilities.TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED.replaceFirst(
+                                "[%]s",
+                                CompileTestUtilities.ANONYMOUS_CLASS.replaceFirst("[%]s", AbstractProcessor.class.getCanonicalName())
+                        )
+                                .replaceFirst("[%]s", "" + System.identityHashCode(processor))
+                )
+        );
+    }
+
+    @Test
+    public void getAnnotationProcessorWasAppliedMessage_anynomousProcessor_interface() {
+
+        Processor processor = new Processor() {
+            @Override
+            public Set<String> getSupportedOptions() {
+                return null;
+            }
+
+            @Override
+            public Set<String> getSupportedAnnotationTypes() {
+                return null;
+            }
+
+            @Override
+            public SourceVersion getSupportedSourceVersion() {
+                return null;
+            }
+
+            @Override
+            public void init(ProcessingEnvironment processingEnv) {
+
+            }
+
+            @Override
+            public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                return false;
+            }
+
+            @Override
+            public Iterable<? extends Completion> getCompletions(Element element, AnnotationMirror annotation, ExecutableElement member, String userText) {
+                return null;
+            }
+        };
+
+        MatcherAssert.assertThat(
+                CompileTestUtilities.getAnnotationProcessorWasAppliedMessage(processor),
+                Matchers.equalTo(
+
+                        CompileTestUtilities.TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED.replaceFirst(
+                                "[%]s",
+                                CompileTestUtilities.ANONYMOUS_CLASS
+                                        .replaceFirst("[%]s", Processor.class.getCanonicalName()
+                                        )
+
+                        )
+                                .replaceFirst("[%]s", "" + System.identityHashCode(processor)
+                                )
+                )
+
+        );
+    }
+
+    @Test
+    public void getAnnotationProcessorWasAppliedMessage_nullValueProcessor() {
+        MatcherAssert.assertThat(
+                CompileTestUtilities.getAnnotationProcessorWasAppliedMessage(null),
+                Matchers.equalTo(CompileTestUtilities.TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED.replaceFirst("[%]s", "").replaceFirst("[#][%]s", "#NULL")));
+    }
+
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/integrationtest/CompiledClassesAndGeneratedFilesTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/integrationtest/CompiledClassesAndGeneratedFilesTest.java
@@ -1,0 +1,180 @@
+package io.toolisticon.compiletesting.integrationtest;
+
+import io.toolisticon.compiletesting.CompileTestBuilder;
+import io.toolisticon.compiletesting.JavaFileObjectUtils;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor1;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Integration test to test if expected compiled classes and generated files exists.
+ */
+public class CompiledClassesAndGeneratedFilesTest {
+
+
+    @Test
+    public void testCompiledClassesExist() {
+
+        CompileTestBuilder.compilationTest()
+                .addProcessors(SimpleTestProcessor1.class)
+                .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java"))
+                .compilationShouldSucceed()
+                .expectedJavaFileObjectExists(StandardLocation.CLASS_OUTPUT, "io.toolisticon.compiletesting.integrationtest.CompiledClassesAndGeneratedFilesExistTestcase", JavaFileObject.Kind.CLASS)
+                .testCompilation();
+
+
+    }
+
+
+    public static class FileGeneratorProcessor extends SimpleTestProcessor1 {
+
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
+            if (roundEnv.processingOver()) {
+                try {
+
+                    FileObject out = processingEnv.getFiler().createResource(StandardLocation.SOURCE_OUTPUT, "", "/META-INF/jupp.txt");
+
+
+                    BufferedWriter writer = new BufferedWriter(out.openWriter());
+
+                    writer.write("XXX");
+
+                    writer.flush();
+                    writer.close();
+
+                } catch (IOException e) {
+                    throw new RuntimeException("ERROR! " + e.getMessage(), e);
+                }
+
+            }
+
+            return false;
+        }
+
+
+    }
+
+    @Test
+    public void testCompiledResourceExist() {
+
+        CompileTestBuilder.compilationTest()
+                .addProcessors(FileGeneratorProcessor.class)
+                .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java"))
+                .compilationShouldSucceed()
+                .expectedFileObjectExists(StandardLocation.SOURCE_OUTPUT, "/META-INF", "jupp.txt", JavaFileObjectUtils.readFromString( "XXX"))
+                .testCompilation();
+
+
+    }
+
+    @Test
+    public void testCompiledResourceNotExist() {
+
+        boolean assertionErrorWasThrown = false;
+
+        try {
+            CompileTestBuilder.compilationTest()
+                    .addProcessors(FileGeneratorProcessor.class)
+                    .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java"))
+                    .compilationShouldSucceed()
+                    .expectedFileObjectExists(StandardLocation.SOURCE_OUTPUT, "/META-INF", "jupp.txt", JavaFileObjectUtils.readFromString("XXX!!!"))
+                    .testCompilation();
+        } catch (AssertionError e) {
+
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("exists but doesn't match expected"));
+            assertionErrorWasThrown = true;
+
+        }
+
+        MatcherAssert.assertThat("AssertError should have  been thrown", assertionErrorWasThrown);
+
+    }
+
+
+    public static class JavaFileGeneratorProcessor extends SimpleTestProcessor1 {
+
+        public final static String PACKAGE_NAME = "io.toolisticon.compiletesting.integrationtest";
+        public final static String CLASS_NAME = "CreatedSourceFile";
+
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
+            if (roundEnv.processingOver()) {
+                try {
+
+                    FileObject out = processingEnv.getFiler().createSourceFile(PACKAGE_NAME + "." + CLASS_NAME);
+
+
+                    BufferedWriter writer = new BufferedWriter(out.openWriter());
+
+                    writer.write("package " + PACKAGE_NAME + ";\n");
+                    writer.write("public class " + CLASS_NAME + "{\n}");
+
+                    writer.flush();
+                    writer.close();
+
+                } catch (IOException e) {
+                    throw new RuntimeException("ERROR! " + e.getMessage(), e);
+                }
+
+            }
+
+            return false;
+        }
+
+
+    }
+
+    @Test
+    public void testCompiledJavaFileObjectExist() {
+
+        CompileTestBuilder.compilationTest()
+                .addProcessors(JavaFileGeneratorProcessor.class)
+                .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java"))
+                .compilationShouldSucceed()
+                .expectedJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, JavaFileGeneratorProcessor.PACKAGE_NAME + "." + JavaFileGeneratorProcessor.CLASS_NAME, JavaFileObject.Kind.SOURCE)
+                .expectedJavaFileObjectExists(StandardLocation.CLASS_OUTPUT, JavaFileGeneratorProcessor.PACKAGE_NAME + "." + JavaFileGeneratorProcessor.CLASS_NAME, JavaFileObject.Kind.CLASS)
+
+                .testCompilation();
+
+
+    }
+
+    @Test
+    public void testCompiledJavaFileObjectNotExist() {
+
+        boolean assertionErrorWasThrown = false;
+
+        try {
+            CompileTestBuilder.compilationTest()
+                    .addProcessors(FileGeneratorProcessor.class)
+                    .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java"))
+                    .compilationShouldSucceed()
+                    .expectedJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, JavaFileGeneratorProcessor.PACKAGE_NAME + ".Murks", JavaFileObject.Kind.SOURCE)
+                    .testCompilation();
+        } catch (AssertionError e) {
+
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("doesn't exist"));
+            assertionErrorWasThrown = true;
+
+        }
+
+        MatcherAssert.assertThat("AssertError should have  been thrown", assertionErrorWasThrown);
+
+    }
+
+}

--- a/compile-testing/src/test/java/io/toolisticon/compiletesting/integrationtest/ProcessorWasAppliedTest.java
+++ b/compile-testing/src/test/java/io/toolisticon/compiletesting/integrationtest/ProcessorWasAppliedTest.java
@@ -1,0 +1,117 @@
+package io.toolisticon.compiletesting.integrationtest;
+
+import io.toolisticon.compiletesting.CompileTestBuilder;
+import io.toolisticon.compiletesting.JavaFileObjectUtils;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor1;
+import io.toolisticon.compiletesting.common.SimpleTestProcessor2;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Integration test to check if annotation processor was detected as applied correctly.
+ */
+public class ProcessorWasAppliedTest {
+
+    @Test
+    public void concreteProcessorClassInstance_wasApplied() {
+
+        CompileTestBuilder
+                .unitTest()
+                .useProcessor(new SimpleTestProcessor1())
+                .useSource(JavaFileObjectUtils.readFromResource("/integrationtest/AnnotationProcessorAppliedTestClass.java"))
+                .testCompilation();
+
+
+    }
+
+    @Test
+    public void concreteProcessorClassInstance_wasNotApplied() {
+        boolean assertionErrorWasTriggered = false;
+        try {
+            CompileTestBuilder
+                    .unitTest()
+                    .useProcessor(new SimpleTestProcessor2())
+                    .useSource(JavaFileObjectUtils.readFromResource("/integrationtest/AnnotationProcessorAppliedTestClass.java"))
+                    .testCompilation();
+
+        } catch (AssertionError e) {
+            assertionErrorWasTriggered = true;
+
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("hasn't been applied on a class"));
+
+        }
+
+        MatcherAssert.assertThat("AssertionError should have been triggered", assertionErrorWasTriggered);
+
+    }
+
+    @Test
+    public void anonymousProcessorClassInstanceOfProcessor_wasApplied() {
+        CompileTestBuilder
+                .unitTest()
+                .useProcessor(new SimpleTestProcessor1() {
+                })
+                .useSource(JavaFileObjectUtils.readFromResource("/integrationtest/AnnotationProcessorAppliedTestClass.java"))
+                .testCompilation();
+
+    }
+
+    @Test
+    public void anonymousProcessorClassInstanceOfProcessor_wasNotApplied() {
+        boolean assertionErrorWasTriggered = false;
+        try {
+            CompileTestBuilder
+                    .unitTest()
+                    .useProcessor(new SimpleTestProcessor2() {
+                    })
+                    .useSource(JavaFileObjectUtils.readFromResource("/integrationtest/AnnotationProcessorAppliedTestClass.java"))
+                    .testCompilation();
+
+        } catch (AssertionError e) {
+            assertionErrorWasTriggered = true;
+
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("hasn't been applied on a class"));
+
+        }
+
+        MatcherAssert.assertThat("AssertionError should have been triggered", assertionErrorWasTriggered);
+
+    }
+
+    @Test
+    public void anonymousProcessorClassInstanceOfClass_wasApplied() {
+
+        CompileTestBuilder
+                .compilationTest()
+                .addProcessors(SimpleTestProcessor1.class)
+                .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/AnnotationProcessorAppliedTestClass.java"))
+                .testCompilation();
+
+    }
+
+    @Test
+    public void anonymousProcessorClassInstanceOfClass_wasNotApplied() {
+
+        boolean assertionErrorWasTriggered = false;
+        try {
+
+            CompileTestBuilder
+                    .compilationTest()
+                    .addProcessors(SimpleTestProcessor2.class)
+                    .addSources(JavaFileObjectUtils.readFromResource("/integrationtest/AnnotationProcessorAppliedTestClass.java"))
+                    .testCompilation();
+
+        } catch (AssertionError e) {
+            assertionErrorWasTriggered = true;
+
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("hasn't been applied on a class"));
+
+        }
+
+        MatcherAssert.assertThat("AssertionError should have been triggered", assertionErrorWasTriggered);
+
+
+    }
+
+}

--- a/compile-testing/src/test/resources/integrationtest/AnnotationProcessorAppliedTestClass.java
+++ b/compile-testing/src/test/resources/integrationtest/AnnotationProcessorAppliedTestClass.java
@@ -1,0 +1,8 @@
+package io.toolisticon.compiletesting.integrationtest;
+
+import io.toolisticon.compiletesting.common.SimpleTestAnnotation1;
+
+@SimpleTestAnnotation1
+public class AnnotationProcessorAppliedTestClass {
+    
+}

--- a/compile-testing/src/test/resources/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java
+++ b/compile-testing/src/test/resources/integrationtest/CompiledClassesAndGeneratedFilesExistTestcase.java
@@ -1,0 +1,9 @@
+package io.toolisticon.compiletesting.integrationtest;
+
+import io.toolisticon.compiletesting.common.SimpleTestAnnotation1;
+
+@SimpleTestAnnotation1
+public class CompiledClassesAndGeneratedFilesExistTestcase {
+
+
+}

--- a/extension/junit4/src/main/java/io/toolisticon/compiletesting/extension/junit4/JUnit4Assertion.java
+++ b/extension/junit4/src/main/java/io/toolisticon/compiletesting/extension/junit4/JUnit4Assertion.java
@@ -4,7 +4,7 @@ import io.toolisticon.compiletesting.extension.api.AssertionSpi;
 import io.toolisticon.spiap.api.Service;
 import org.junit.Assert;
 
-@Service(value = AssertionSpi.class, priority = 0, description = "junit 4 is default assertion framework")
+@Service(value = AssertionSpi.class, priority = -5, description = "junit 4 assertion framework")
 public class JUnit4Assertion implements AssertionSpi {
     @Override
     public void fail(String message) {

--- a/extension/plainjava/pom.xml
+++ b/extension/plainjava/pom.xml
@@ -1,0 +1,115 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>extension-plainjava</artifactId>
+    <packaging>bundle</packaging>
+
+    <parent>
+        <groupId>io.toolisticon.compiletesting</groupId>
+        <artifactId>extension-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <name>extension-plainjava</name>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.toolisticon.compiletesting</groupId>
+            <artifactId>extension-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.spiap</groupId>
+            <artifactId>spiap-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.spiap</groupId>
+            <artifactId>spiap-processor</artifactId>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>io.toolisticon.compiletesting.extension.junit4</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.0.4,)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.6</version>
+                                </requireJavaVersion>
+                                <bannedDependencies>
+                                    <searchTransitive>false</searchTransitive>
+                                    <excludes>
+                                        <exclude>*</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>io.toolisticon.compiletesting:extension-api:*</include>
+                                        <include>io.toolisticon.spiap:provided</include>
+                                        <include>*:*:*:*:test:*</include>
+                                        <include>*:*:*:*:provided:*</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>target/generated-sources/annotations</directory>
+                                    <targetPath/>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+
+        </plugins>
+
+
+    </build>
+
+</project>

--- a/extension/plainjava/src/main/java/io/toolisticon/compiletesting/extension/def/AssertionErrorAssertion.java
+++ b/extension/plainjava/src/main/java/io/toolisticon/compiletesting/extension/def/AssertionErrorAssertion.java
@@ -1,0 +1,13 @@
+package io.toolisticon.compiletesting.extension.def;
+
+
+import io.toolisticon.compiletesting.extension.api.AssertionSpi;
+import io.toolisticon.spiap.api.Service;
+
+@Service(value = AssertionSpi.class, priority = 0, description = "Java's AssertionError should work with all testing frameworks")
+public class AssertionErrorAssertion implements AssertionSpi {
+    @Override
+    public void fail(String message) {
+        throw new AssertionError(message);
+    }
+}

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -15,6 +15,7 @@
 
     <modules>
         <module>api</module>
+        <module>plainjava</module>
         <module>junit4</module>
         <module>testng</module>
     </modules>

--- a/integration-test/junit5/src/test/java/io/toolisticon/compiletest/integrationtest/testng/Junit5Test.java
+++ b/integration-test/junit5/src/test/java/io/toolisticon/compiletest/integrationtest/testng/Junit5Test.java
@@ -18,7 +18,7 @@ public class Junit5Test {
     @Test
     public void warningMessageTest() {
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .unitTest()
                 .useProcessor(new UnitTestProcessor() {
                     @Override
@@ -26,7 +26,7 @@ public class Junit5Test {
                         processingEnvironment.getMessager().printMessage(Diagnostic.Kind.WARNING, "WARNING!");
                     }
                 })
-                .addWarningChecks("WARNING!")
+                .expectedWarningMessages("WARNING!")
                 .compilationShouldSucceed()
                 .testCompilation();
 
@@ -36,7 +36,7 @@ public class Junit5Test {
     @Test
     public void successfullFailingCompilationTest_ByErrorMessage() {
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .unitTest()
                 .useProcessor(new UnitTestProcessor() {
                     @Override
@@ -44,7 +44,7 @@ public class Junit5Test {
                         processingEnvironment.getMessager().printMessage(Diagnostic.Kind.ERROR, "ERROR!");
                     }
                 })
-                .addErrorChecks("ERROR!")
+                .expectedErrorMessages("ERROR!")
                 .compilationShouldFail()
                 .testCompilation();
 
@@ -55,7 +55,7 @@ public class Junit5Test {
     public void failingCompilationTest_ByErrorMessage() {
 
         try {
-            CompileTestBuilder.createCompileTestBuilder()
+            CompileTestBuilder
                     .unitTest()
                     .useProcessor(new UnitTestProcessor() {
                         @Override

--- a/integration-test/testng/src/test/java/io/toolisticon/compiletest/integrationtest/testng/TestNgTest.java
+++ b/integration-test/testng/src/test/java/io/toolisticon/compiletest/integrationtest/testng/TestNgTest.java
@@ -17,7 +17,8 @@ public class TestNgTest {
     @Test
     public void warningMessageTest() {
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
+
                 .unitTest()
                 .useProcessor(new UnitTestProcessor() {
                     @Override
@@ -25,7 +26,7 @@ public class TestNgTest {
                         processingEnvironment.getMessager().printMessage(Diagnostic.Kind.WARNING, "WARNING!");
                     }
                 })
-                .addWarningChecks("WARNING!")
+                .expectedWarningMessages("WARNING!")
                 .compilationShouldSucceed()
                 .testCompilation();
 
@@ -35,7 +36,7 @@ public class TestNgTest {
     @Test
     public void successfullFailingCompilationTest_ByErrorMessage() {
 
-        CompileTestBuilder.createCompileTestBuilder()
+        CompileTestBuilder
                 .unitTest()
                 .useProcessor(new UnitTestProcessor() {
                     @Override
@@ -43,7 +44,7 @@ public class TestNgTest {
                         processingEnvironment.getMessager().printMessage(Diagnostic.Kind.ERROR, "ERROR!");
                     }
                 })
-                .addErrorChecks("ERROR!")
+                .expectedErrorMessages("ERROR!")
                 .compilationShouldFail()
                 .testCompilation();
 
@@ -54,7 +55,7 @@ public class TestNgTest {
     public void failingCompilationTest_ByErrorMessage() {
 
         try {
-            CompileTestBuilder.createCompileTestBuilder()
+            CompileTestBuilder
                     .unitTest()
                     .useProcessor(new UnitTestProcessor() {
                         @Override


### PR DESCRIPTION
Aditionally removed possibility to pass processor instances in compile test builder (unit test builder is ok to pass instances)
It’s now possible to add processor types that are instanciated freshly at the beginning of the test.