### PR TITLE
Enhance debugging output in case of failing tests

### DIFF
--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/AnnotationProcessorWrapper.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/AnnotationProcessorWrapper.java
@@ -86,13 +86,13 @@ public final class AnnotationProcessorWrapper implements Processor {
             if (this.expectedThrownException != null) {
 
                 if (!this.expectedThrownException.isAssignableFrom(e.getClass())) {
-                    AssertionSpiServiceLocator.locate().fail("Expected exception of type '" + this.expectedThrownException.getCanonicalName() + "' but exception of type '" + e.getClass().getCanonicalName() + (e.getMessage() != null ? "'  with message '" + e.getMessage() : "") + "' was thrown instead.");
+                    throw new FailingAssertionException("Expected exception of type '" + this.expectedThrownException.getCanonicalName() + "' but exception of type '" + e.getClass().getCanonicalName() + (e.getMessage() != null ? "'  with message '" + e.getMessage() : "") + "' was thrown instead.", e);
                 }
 
             } else {
 
                 // Got unexpected exception
-                AssertionSpiServiceLocator.locate().fail("An unexpected exception of type '" + e.getClass().getCanonicalName() + (e.getMessage() != null ? "'  with message '" + e.getMessage() : "") + "' has been thrown.");
+                throw new FailingAssertionException("An unexpected exception of type '" + e.getClass().getCanonicalName() + (e.getMessage() != null ? "'  with message '" + e.getMessage() : "") + "' has been thrown.", e);
 
             }
 
@@ -102,7 +102,7 @@ public final class AnnotationProcessorWrapper implements Processor {
 
         // check in last round if expected exception has been thrown
         if (roundEnv.processingOver() && expectedExceptionWasThrown && this.expectedThrownException != null) {
-            AssertionSpiServiceLocator.locate().fail("Expected exception of type '" + this.expectedThrownException.getCanonicalName() + "' to be thrown, but wasn't");
+            throw new FailingAssertionException("Expected exception of type '" + this.expectedThrownException.getCanonicalName() + "' to be thrown, but wasn't");
         }
 
         return returnValue;

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestFileManager.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestFileManager.java
@@ -18,8 +18,10 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -49,6 +51,10 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
             return fileObjectCache.values();
         }
 
+        public boolean isEmpty() {
+            return fileObjectCache.isEmpty();
+        }
+
 
     }
 
@@ -59,6 +65,14 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
 
     public CompileTestFileManager(StandardJavaFileManager standardJavaFileManager) {
         super(standardJavaFileManager);
+    }
+
+    List<JavaFileObject> getGeneratedJavaFileObjects() {
+        return new ArrayList<JavaFileObject>(generatedJavaFileObjectCache.getEntries());
+    }
+
+    List<FileObject> getGeneratedFileObjects() {
+        return new ArrayList<FileObject>(generatedFileObjectCache.getEntries());
     }
 
     @Override
@@ -119,6 +133,7 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
         return super.getFileForInput(location, packageName, relativeName);
     }
 
+
     /**
      * Checks if JavaFileObject for passed parameters exists.
      *
@@ -147,7 +162,7 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
 
     }
 
-
+/*-
     public String getGeneratedFileOverview() {
 
         StringBuilder stringBuilder = new StringBuilder();
@@ -218,7 +233,7 @@ public class CompileTestFileManager extends ForwardingJavaFileManager<StandardJa
         return stringBuilder.toString();
 
     }
-
+*/
 
     public static boolean contentEquals(InputStream input1, InputStream input2) throws IOException {
         if (!(input1 instanceof BufferedInputStream)) {

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestUtilities.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/CompileTestUtilities.java
@@ -1,14 +1,19 @@
 package io.toolisticon.compiletesting.impl;
 
 import javax.annotation.processing.Processor;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Some static utility functions.
  */
-public class CompileTestUtilities {
+final class CompileTestUtilities {
 
-    protected static final String ANONYMOUS_CLASS = "ANONYMOUS CLASS<%s>";
-    protected final static String TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED = "!!!--- ANNOTATION PROCESSOR (%s)<#%s> WAS APPPLIED ---!!!";
+    static final String ANONYMOUS_CLASS = "ANONYMOUS CLASS<%s>";
+    final static String TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED = "!!!--- ANNOTATION PROCESSOR (%s)<#%s> WAS APPPLIED ---!!!";
 
     /**
      * Hidden constructor.
@@ -23,7 +28,7 @@ public class CompileTestUtilities {
      * @param processor the processor to create the message for
      * @return the message to check if processor has been applied
      */
-    public static String getAnnotationProcessorWasAppliedMessage(Processor processor) {
+    static String getAnnotationProcessorWasAppliedMessage(Processor processor) {
         return String.format(TEMPLATE_ANNOTATION_PROCESSOR_WAS_APPLIED,
                 processor != null && processor.getClass() != null ? (
                         processor.getClass().getCanonicalName() != null ?
@@ -34,7 +39,48 @@ public class CompileTestUtilities {
                                                 : processor.getClass().getSuperclass().getCanonicalName()
                                 )
                 ) : "",
-                processor!= null ? System.identityHashCode(processor): "NULL");
+                processor != null ? System.identityHashCode(processor) : "NULL");
+    }
+
+    /**
+     * Gets all messages of a specific kind.
+     *
+     * @param diagnostics the compilations diagnostics result
+     * @param kind        the kind of the messages to return
+     * @return a Set containing all messages of passed kind, or an empty Set.
+     */
+    static Set<String> getMessages(DiagnosticCollector<JavaFileObject> diagnostics, Diagnostic.Kind kind) {
+
+        Set<String> messages = new HashSet<String>();
+        Set<Diagnostic> flteredDiagnoistics = getDiagnosticByKind(diagnostics, kind);
+
+        for (Diagnostic diagnostic : flteredDiagnoistics) {
+            messages.add(diagnostic.getMessage(null));
+        }
+
+        return messages;
+
+    }
+
+    /**
+     * Filters Diagnostics by kind.
+     *
+     * @param diagnostics the compilations diagnostics result
+     * @param kind        the kind of the messages to return
+     * @return a Set containing all Diagnostic element of passed kind, or an empty Set.
+     */
+    static Set<Diagnostic> getDiagnosticByKind(DiagnosticCollector<JavaFileObject> diagnostics, Diagnostic.Kind kind) {
+
+        Set<Diagnostic> filteredDiagnostics = new HashSet<Diagnostic>();
+
+        for (Diagnostic diagnostic : diagnostics.getDiagnostics()) {
+            if (kind == diagnostic.getKind()) {
+                filteredDiagnostics.add(diagnostic);
+            }
+        }
+
+        return filteredDiagnostics;
+
     }
 
 }

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/DebugOutputGenerator.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/DebugOutputGenerator.java
@@ -1,0 +1,127 @@
+package io.toolisticon.compiletesting.impl;
+
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility class to generate debug output
+ */
+final class DebugOutputGenerator {
+
+    /**
+     * Hidden constructor.
+     */
+    private DebugOutputGenerator() {
+
+    }
+
+    static String getDebugOutput(CompilationResult compilationResult, CompileTestConfiguration compileTestConfiguration, FailingAssertionException failingAssertionException) {
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        // unexpected exception
+        if (failingAssertionException != null && failingAssertionException.getCause() != null) {
+
+            StringWriter stacktraceStringWriter = new StringWriter();
+            PrintWriter stacktracePrintWriter = new PrintWriter(stacktraceStringWriter);
+            failingAssertionException.getCause().printStackTrace(stacktracePrintWriter);
+
+            String message = failingAssertionException.getCause().getMessage();
+
+            stringBuilder.append(getDebugOutputHeader("UNEXPECTED EXCEPTION"))
+                    .append("MESSAGE : ").append(message != null ? message : "<NO MESSSAGE>").append("\n")
+                    .append("STACKTRACE : ").append(stacktraceStringWriter.toString()).append("\n");
+        }
+
+        if (compilationResult != null) {
+            // Error and warning messages
+            stringBuilder.append(getDebugMessages(compilationResult, Diagnostic.Kind.ERROR));
+            stringBuilder.append(getDebugMessages(compilationResult, Diagnostic.Kind.MANDATORY_WARNING));
+            stringBuilder.append(getDebugMessages(compilationResult, Diagnostic.Kind.WARNING));
+
+
+            // Generated File objects
+            stringBuilder.append(getDebugOutputHeader("GENERATED FILEOBJECTS")).append(getGeneratedFileOverview(compilationResult));
+
+        }
+
+        // Compile test configuration
+        stringBuilder.append(getDebugOutputHeader("COMPILE TEST CONFIGURATION")).append(compileTestConfiguration.toString());
+
+        return stringBuilder.toString();
+
+    }
+
+    private static String getDebugOutputHeader(String headerString) {
+        return String.format("\n-------------------------------\n-- %s: \n-------------------------------\n", headerString.toUpperCase());
+    }
+
+    private static String getDebugMessages(CompilationResult compilationResult, Diagnostic.Kind kind) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        Set<Diagnostic> filteredDiagnostics = CompileTestUtilities.getDiagnosticByKind(compilationResult.getDiagnostics(), kind);
+        if (!filteredDiagnostics.isEmpty()) {
+            stringBuilder.append(getDebugOutputHeader(kind.toString() + " MESSAGES"));
+
+            int i = 1;
+            for (Diagnostic diagnostics : filteredDiagnostics) {
+
+
+                stringBuilder.append("[").append(i).append("]'")
+                        .append(diagnostics)
+                        .append("'\n");
+                i++;
+            }
+
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private static String getGeneratedFileOverview(CompilationResult compilationResult) {
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+
+        stringBuilder
+                .append("{\n")
+                .append("  'GENERATED JAVA FILE OBJECTS' : ")
+                .append(createGeneratedFileObjectOverview(compilationResult.getCompileTestFileManager().getGeneratedJavaFileObjects()))
+                .append(",\n  'GENERATED FILE OBJECTS' :")
+                .append(createGeneratedFileObjectOverview(compilationResult.getCompileTestFileManager().getGeneratedFileObjects()))
+                .append("\n}");
+
+
+        return stringBuilder.toString();
+
+    }
+
+    private static  <FILE_OBJECT extends FileObject> String createGeneratedFileObjectOverview(List<FILE_OBJECT> fileObjects) {
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        if (fileObjects.isEmpty()) {
+            stringBuilder.append("'No files were generated !!!'");
+        } else {
+
+            stringBuilder.append("[\n");
+
+            for (FILE_OBJECT fileObject : fileObjects) {
+
+                stringBuilder.append("    '" + fileObject.toUri().toString() + "'").append(", \n");
+
+            }
+
+            stringBuilder.append("  ]");
+        }
+
+
+        return stringBuilder.toString();
+
+    }
+
+}

--- a/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/FailingAssertionException.java
+++ b/compile-testing/src/main/java/io/toolisticon/compiletesting/impl/FailingAssertionException.java
@@ -1,0 +1,16 @@
+package io.toolisticon.compiletesting.impl;
+
+/**
+ * Exception to signal failing Assertion
+ */
+public class FailingAssertionException extends RuntimeException {
+
+    public FailingAssertionException(String message) {
+        super(message);
+    }
+
+    public FailingAssertionException(String message, Throwable e) {
+        super(message,e);
+    }
+
+}

--- a/integration-test/junit4/pom.xml
+++ b/integration-test/junit4/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>integration-test-junit4</artifactId>

--- a/integration-test/junit4/src/test/java/io/toolisticon/compiletest/integrationtest/junit4/Junit4Test.java
+++ b/integration-test/junit4/src/test/java/io/toolisticon/compiletest/integrationtest/junit4/Junit4Test.java
@@ -3,6 +3,10 @@ package io.toolisticon.compiletest.integrationtest.junit4;
 
 import io.toolisticon.compiletesting.CompileTestBuilder;
 import io.toolisticon.compiletesting.UnitTestProcessor;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -68,7 +72,7 @@ public class Junit4Test {
 
             Assert.fail("Should have failed");
         } catch (AssertionError error) {
-            Assert.assertEquals(error.getMessage(), "Compilation should have succeeded but failed");
+            MatcherAssert.assertThat(error.getMessage(), Matchers.containsString("Compilation should have succeeded but failed"));
         }
 
     }

--- a/integration-test/testng/src/test/java/io/toolisticon/compiletest/integrationtest/testng/TestNgTest.java
+++ b/integration-test/testng/src/test/java/io/toolisticon/compiletest/integrationtest/testng/TestNgTest.java
@@ -2,6 +2,8 @@ package io.toolisticon.compiletest.integrationtest.testng;
 
 import io.toolisticon.compiletesting.CompileTestBuilder;
 import io.toolisticon.compiletesting.UnitTestProcessor;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -68,7 +70,7 @@ public class TestNgTest {
 
             Assert.fail("Should have failed");
         } catch (AssertionError error) {
-            Assert.assertEquals(error.getMessage(),"Compilation should have succeeded but failed");
+            MatcherAssert.assertThat(error.getMessage(), Matchers.containsString("Compilation should have succeeded but failed"));
         }
 
     }


### PR DESCRIPTION
Usually a developer needs access to detailed information to be able to fix failing tests or bugs.

The following debug output has been enhanced/created:
- error and (mandatory) warnings
- unexpected exceptions
- write generated files to disk (target/compileTesting_failingUnitTests folder)
