### PR TITLE
[#3] Remove need of spiap-api runtime dependency

### DIFF
--- a/extension/api/pom.xml
+++ b/extension/api/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>extension-api</artifactId>
@@ -18,7 +19,6 @@
         <dependency>
             <groupId>io.toolisticon.spiap</groupId>
             <artifactId>spiap-api</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -94,7 +94,7 @@
                             <resources>
                                 <resource>
                                     <directory>target/generated-sources/annotations</directory>
-                                    <targetPath />
+                                    <targetPath/>
                                 </resource>
                             </resources>
                         </configuration>

--- a/integration-test/junit4/pom.xml
+++ b/integration-test/junit4/pom.xml
@@ -32,10 +32,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.toolisticon.spiap</groupId>
-            <artifactId>spiap-processor</artifactId>
-        </dependency>
 
     </dependencies>
 

--- a/integration-test/junit5/pom.xml
+++ b/integration-test/junit5/pom.xml
@@ -33,11 +33,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.toolisticon.spiap</groupId>
-            <artifactId>spiap-processor</artifactId>
-        </dependency>
-
     </dependencies>
 
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>integration-test-parent</artifactId>

--- a/integration-test/testng/pom.xml
+++ b/integration-test/testng/pom.xml
@@ -33,10 +33,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.toolisticon.spiap</groupId>
-            <artifactId>spiap-processor</artifactId>
-        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.toolisticon.compiletesting</groupId>
@@ -79,7 +80,7 @@
         <java.compile.target.version>1.6</java.compile.target.version>
 
         <!-- dependencies: compile and runtime -->
-        <spiap.version>0.5.1</spiap.version>
+        <spiap.version>0.7.0</spiap.version>
 
         <!-- versions of test dependencies -->
         <junit4.version>4.12</junit4.version>


### PR DESCRIPTION
switched to spiap version 0.7.0 which stores annotation based configuration in properties.